### PR TITLE
get_key_references was moved to account_by_key_api

### DIFF
--- a/src/api/methods.json
+++ b/src/api/methods.json
@@ -166,7 +166,7 @@
     "method": "get_next_scheduled_hardfork"
   },
   {
-    "api": "database_api",
+    "api": "account_by_key_api",
     "method": "get_key_references",
     "params": ["key"]
   },


### PR DESCRIPTION
get_key_references was moved to the own api "account_by_key_api". 