### PR TITLE
inFlight should only count active requests

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -246,11 +246,10 @@ class Steem extends EventEmitter {
         });
 
         debugWs('Sending message', payload);
+        this.inFlight += 1;
         this.ws.send(payload);
       }))
       .nodeify(callback);
-
-    this.inFlight += 1;
 
     return this.currentP;
   }


### PR DESCRIPTION
Example Issue:
1) submit 25 concurrent requests (inFlight = 25)
2) 10 messages get processed (inFlight = 15)
3) waitForSlot expects `inFlight < 10` to process more msgs

This change is to count only active (not queued) requests