### PR TITLE
fix chain time access, remove local time fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steem",
-  "version": "0.5.2",
+  "version": "0.5.4",
   "description": "Steem.js the JavaScript API for Steem blockchain",
   "main": "index.js",
   "scripts": {

--- a/src/broadcast/index.js
+++ b/src/broadcast/index.js
@@ -53,11 +53,12 @@ steemBroadcast._prepareTransaction = function steemBroadcast$_prepareTransaction
   return propertiesP
     .then((properties) => {
       // Set defaults on the transaction
+      const chainDate = new Date(properties.time + 'Z');
       return Object.assign({
         ref_block_num: properties.head_block_number & 0xFFFF,
         ref_block_prefix: new Buffer(properties.head_block_id, 'hex').readUInt32LE(4),
         expiration: new Date(
-          (properties.timestamp || Date.now()) +
+          chainDate.getTime() +
             15 * 1000
         ),
       }, tx);


### PR DESCRIPTION
`properties.timestamp` is undefined, causing clients to fall back to `Date.now()`, which seems to be a bit unreliable as we've had a handful of error reports the last 2 days.

This change fixes chain time access and removes the local time fallback. I notice that in the old steemjs code, this fallback didn't exist. So I think it should be fine to always rely on dynamic_global_props.

#### Reference

old strategy
https://github.com/steemit/condenser/blob/b662db62ecb2fa57fd7d6ae8e130fb009e24cfb0/shared/chain/transactions.js#L30-L31

new strategy
https://github.com/steemit/steem-js/blob/33e97ffc8af12247ee1780c5c2b18ac3d4ed1b85/src/broadcast/index.js#L59-L62