### PR TITLE
Fix #124 and improve test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Steem.js the JavaScript API for Steem blockchain",
   "main": "index.js",
   "scripts": {
-    "test": "eslint --quiet src test; mocha -t 20000 -g 'steem.auth' --require babel-polyfill --require babel-register",
+    "test": "eslint --quiet src test; mocha -t 20000 --require babel-polyfill --require babel-register",
+    "test-auth": "npm test -- --grep 'steem.auth'",
     "build": "npm run build-browser && npm run build-node",
     "build-browser": "rm -rf dist && NODE_ENV=production webpack && gzip -k -f ./dist/*.js && du -h ./dist/*",
     "build-node": "mkdir -p ./lib && cp -r ./src/* ./lib/ && babel ./src --out-dir ./lib",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Steem.js the JavaScript API for Steem blockchain",
   "main": "index.js",
   "scripts": {
-    "test": "eslint --quiet src test; mocha -t 20000 --require babel-polyfill --require babel-register",
+    "test": "eslint --quiet src test; mocha -t 20000 -g 'steem.auth' --require babel-polyfill --require babel-register",
     "build": "npm run build-browser && npm run build-node",
     "build-browser": "rm -rf dist && NODE_ENV=production webpack && gzip -k -f ./dist/*.js && du -h ./dist/*",
     "build-node": "mkdir -p ./lib && cp -r ./src/* ./lib/ && babel ./src --out-dir ./lib",

--- a/src/auth/serializer/src/operations.js
+++ b/src/auth/serializer/src/operations.js
@@ -50,7 +50,6 @@ const {
 const future_extensions = types.void
 const hardfork_version_vote = types.void
 const version = types.void
-const comment_payout_beneficiaries = types.void
 
 // Place-holder, their are dependencies on "operation" .. The final list of
 // operations is not avialble until the very end of the generated code.
@@ -63,6 +62,15 @@ const Serializer=function(operation_name, serilization_types_object){
     const s = new SerializerImpl(operation_name, serilization_types_object);
     return module.exports[operation_name] = s;
 }
+
+const beneficiaries = new Serializer("beneficiaries", {
+  account: string,
+  weight: uint16
+});
+
+const comment_payout_beneficiaries = new Serializer(0, {
+  beneficiaries: set(beneficiaries)
+});
 
 // Custom-types after Generated code
 

--- a/test/Crypto.js
+++ b/test/Crypto.js
@@ -5,7 +5,7 @@ var secureRandom = require('secure-random');
 var hash = require('../src/auth/ecc/src/hash');
 var key = require('../src/auth/ecc/src/key_utils');
 
-describe("Crypto", function() {
+describe("steem.auth: Crypto", function() {
 
     /*it "Computes public key", ->
         private_key = PrivateKey.fromHex decrypted_key.substring 0, 64
@@ -26,7 +26,7 @@ describe("Crypto", function() {
 
 })
 
-describe("derives", ()=> {
+describe("steem.auth: derives", ()=> {
     
     let one_time_private = PrivateKey.fromHex("8fdfdde486f696fd7c6313325e14d3ff0c34b6e2c390d1944cbfe150f4457168")
     let to_public = PublicKey.fromStringOrThrow("STM7vbxtK1WaZqXsiCHPcjVFBewVj8HFRd5Z5XZDpN6Pvb2dZcMqK")

--- a/test/KeyFormats.js
+++ b/test/KeyFormats.js
@@ -2,7 +2,7 @@ import { PrivateKey, PublicKey, Address } from "../src/auth/ecc";
 import assert from "assert"
 
 var test = function(key) {
-    describe("key_formats", function() {
+    describe("steem.auth: key_formats", function() {
         
         it("Calcualtes public key from private key", function() {
             var private_key = PrivateKey.fromHex(key.private_key);

--- a/test/all_types.js
+++ b/test/all_types.js
@@ -63,7 +63,7 @@ let allTypes = {
     time_point_sec3: '2017-02-16T20:27:12',
 }
 
-describe("all types", ()=> {
+describe("steem.auth: all types", ()=> {
 
     let { toObject, fromObject, toBuffer, fromBuffer } = AllTypes
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -8,7 +8,7 @@ import steem, { Steem } from '../src/api/index';
 import config from '../src/config';
 import testPost from './test-post.json';
 
-describe('steem', function () {
+describe('steem.api:', function () {
   this.timeout(30 * 1000);
 
   describe('new Steem', () => {

--- a/test/broadcast.test.js
+++ b/test/broadcast.test.js
@@ -11,7 +11,7 @@ const postingWif = password
   ? steemAuth.toWif(username, password, 'posting')
   : '5JRaypasxMx1L97ZUX7YuC5Psb5EAbF821kkAGtBj7xCJFQcbLg';
 
-describe('steem.broadcast', () => {
+describe('steem.broadcast:', () => {
   it('exists', () => {
     should.exist(steemBroadcast);
   });

--- a/test/comment.test.js
+++ b/test/comment.test.js
@@ -17,7 +17,7 @@ describe('steem.broadcast', () => {
     });
 
     it('works', async () => {
-      const permlink = new Date().toISOString().toLowerCase();
+      const permlink = new Date().toISOString().replace(/[^a-zA-Z0-9]+/g, '').toLowerCase();
       const operations = [
         ['comment',
           {

--- a/test/comment.test.js
+++ b/test/comment.test.js
@@ -9,7 +9,7 @@ const postingWif = password
   ? steemAuth.toWif(username, password, 'posting')
   : '5JRaypasxMx1L97ZUX7YuC5Psb5EAbF821kkAGtBj7xCJFQcbLg';
 
-describe('steem.broadcast', () => {
+describe('steem.broadcast:', () => {
 
   describe('comment with options', () => {
     before(() => {

--- a/test/comment.test.js
+++ b/test/comment.test.js
@@ -1,0 +1,66 @@
+import Promise from 'bluebird';
+import should from 'should';
+import steemAuth from '../src/auth';
+import steemBroadcast from '../src/broadcast';
+
+const username = process.env.STEEM_USERNAME || 'guest123';
+const password = process.env.STEEM_PASSWORD;
+const postingWif = password
+  ? steemAuth.toWif(username, password, 'posting')
+  : '5JRaypasxMx1L97ZUX7YuC5Psb5EAbF821kkAGtBj7xCJFQcbLg';
+
+describe('steem.broadcast', () => {
+
+  describe('comment with options', () => {
+    before(() => {
+      return Promise.delay(2000);
+    });
+
+    it('works', async () => {
+      const permlink = new Date().toISOString().toLowerCase();
+      const operations = [
+        ['comment',
+          {
+            parent_author: '',
+            parent_permlink: 'test',
+            author: username,
+            permlink,
+            title: 'Test',
+            body: 'Hello!',
+            json_metadata :"{\"tags\":[\"steem\"],\"app\":\"steemjs\/0.5.3\",\"format\":\"markdown\"}"
+          }
+        ],
+        ['comment_options', {
+          author: username,
+          permlink,
+          max_accepted_payout: '1000000.000 SBD',
+          percent_steem_dollars: 10000,
+          allow_votes: true,
+          allow_curation_rewards: true,
+          extensions: [
+            [0, {
+              beneficiaries: [
+                { account: 'good-karma', weight: 2000 },
+                { account: 'null', weight: 5000 }
+              ]
+            }]
+          ]
+        }]
+      ];
+
+      const tx = await steemBroadcast.sendAsync(
+        { operations, extensions: [] },
+        { posting: postingWif }
+      );
+
+      tx.should.have.properties([
+        'expiration',
+        'ref_block_num',
+        'ref_block_prefix',
+        'extensions',
+        'operations',
+        'signatures',
+      ]);
+    });
+  });
+});

--- a/test/memo.test.js
+++ b/test/memo.test.js
@@ -6,7 +6,7 @@ import {PrivateKey} from '../src/auth/ecc';
 const private_key = PrivateKey.fromSeed("")
 const public_key = private_key.toPublicKey()
 
-describe('memo', ()=> {
+describe('steem.auth: memo', ()=> {
     it('plain text', () => {
         const plaintext1 = encode(null/*private_key*/, null/*public_key*/, 'memo')
         assert.equal(plaintext1, 'memo')

--- a/test/number_utils.js
+++ b/test/number_utils.js
@@ -1,7 +1,7 @@
 import assert from "assert"
 import { toImpliedDecimal, fromImpliedDecimal } from "../src/auth/serializer/src/number_utils"
 
-describe("Number utils", () => {
+describe("steem.auth: Number utils", () => {
     
 
     it("to implied decimal", ()=> {

--- a/test/operations_test.js
+++ b/test/operations_test.js
@@ -2,7 +2,7 @@ var assert = require('assert');
 var types = require('../src/auth/serializer/src/types');
 var ops = require('../src/auth/serializer/src/operations');
 
-describe("operation test", ()=> {
+describe("steem.auth: operation test", ()=> {
 
     it("templates", ()=> {
         for(let op in ops) {

--- a/test/types_test.js
+++ b/test/types_test.js
@@ -6,7 +6,7 @@ var type = require('../src/auth/serializer/src/types');
 var p = require('../src/auth/serializer/src/precision');
 var th = require('./test_helper');
 
-describe("types", function() {
+describe("steem.auth: types", function() {
 
     it("vote_id",function() {
         var toHex=function(id){


### PR DESCRIPTION
On this PR:
- Fix issue #124 by adding `comment_payout_beneficiaries` serializer.
- Add a test for broadcast comment + comment_options with beneficiaries.
- Separate test in sub-library (steem.auth, steem.broadcast, steem.api)
- npm test now run only steem.auth related functions by default (removed broadcast operations from default test).