### PR TITLE
change tx expiration from 15s to 60s

### DIFF
--- a/src/broadcast/index.js
+++ b/src/broadcast/index.js
@@ -59,7 +59,7 @@ steemBroadcast._prepareTransaction = function steemBroadcast$_prepareTransaction
         ref_block_prefix: new Buffer(properties.head_block_id, 'hex').readUInt32LE(4),
         expiration: new Date(
           chainDate.getTime() +
-            15 * 1000
+            60 * 1000
         ),
       }, tx);
     });


### PR DESCRIPTION
I've had cases (batch scripts) where 15s was a bit too short. For convenience it might be good to increase default expiration to 60s. Are there any downsides to doing this?