### PR TITLE
Update `recover_account` serializer params

### DIFF
--- a/src/auth/serializer/src/operations.js
+++ b/src/auth/serializer/src/operations.js
@@ -401,12 +401,11 @@ let request_account_recovery = new Serializer(
 }
 );
 
-let recover_account = new Serializer( 
+let recover_account = new Serializer(
     "recover_account", {
     account_to_recover: string,
-    new_owner_authority: authority,
-    recent_owner_authority: authority,
-    extensions: set(future_extensions)
+    new_authority: authority,
+    recent_authority: authority,
 }
 );
 


### PR DESCRIPTION
The operation `recover_account` seem to use an old serializer. I've changed the parameters to follow blockchain API: https://github.com/steemit/steem/blob/a670e4622d99248ecf1a2950acc167e8583bc15e/libraries/wallet/include/steemit/wallet/wallet.hpp#L912