### PR TITLE
Revert changes on `recover_account` serializer

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -742,7 +742,7 @@ steem.broadcast.proveAuthority(wif, challenged, requireOwner, function(err, resu
 ```
 ### Recover Account
 ```
-steem.broadcast.recoverAccount(wif, accountToRecover, recentAuthority, newAuthority, function(err, result) {
+steem.broadcast.recoverAccount(wif, accountToRecover, newOwnerAuthority, recentOwnerAuthority, extensions, function(err, result) {
   console.log(err, result);
 });
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steem",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "Steem.js the JavaScript API for Steem blockchain",
   "main": "index.js",
   "scripts": {

--- a/src/auth/serializer/src/operations.js
+++ b/src/auth/serializer/src/operations.js
@@ -404,8 +404,9 @@ let request_account_recovery = new Serializer(
 let recover_account = new Serializer(
     "recover_account", {
     account_to_recover: string,
-    new_authority: authority,
-    recent_authority: authority,
+    new_owner_authority: authority,
+    recent_owner_authority: authority,
+    extensions: set(future_extensions)
 }
 );
 

--- a/src/broadcast/operations.json
+++ b/src/broadcast/operations.json
@@ -252,8 +252,9 @@
     "operation": "recover_account",
     "params": [
       "account_to_recover",
-      "recent_authority",
-      "new_authority"
+      "new_owner_authority",
+      "recent_owner_authority",
+      "extensions"
     ]
   },
   {


### PR DESCRIPTION
Revert the changes on the operation `recover_account` serializer. I've successfully broadcast `recover_account` operation using `new_owner_authority` and `recent_owner_authority` parameters instead of `new_authority` and `recent_authority` like steem's header file suggest a here: https://github.com/steemit/steem/blob/6fd29bcb0f2c60b71d60a3be0686ffd3673e4658/libraries/wallet/wallet.cpp#L1360