### PR TITLE
Remove usage of JSON files in steem-js

### DIFF
--- a/examples/webpack-example/README.md
+++ b/examples/webpack-example/README.md
@@ -2,23 +2,6 @@
 This is a demo of `steem-js` and webpack usage targetting both the Web and
 Node.js platforms.
 
-## Minimal configuration
-`steem-js` requires JSON files internally, so you need JSON loader configured:
-```json
-{
-  ...
-  module: {
-    loaders: [
-        { test: /\.json$/, loader: 'json-loader'},
-    ]
-  }
-  ...
-}
-```
-
-Make sure `resolve.extensions` and `json-loader`'s `module.loaders[...].exclude`
-do not exclude `.json` files or `node_modules` from resolving.
-
 ## Compiling the example
 Compiling for the web (`bundle.js`, which you can test with `open index.html`):
 ```

--- a/examples/webpack-example/webpack.config.js
+++ b/examples/webpack-example/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
   },
   module: {
     loaders: [
-        { test: /\.json$/, loader: 'json-loader'},
+      // { test: /\.json$/, loader: 'json-loader'},
     ]
   },
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steem",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Steem.js the JavaScript API for Steem blockchain",
   "main": "lib/index.js",
   "scripts": {

--- a/src/api/methods.js
+++ b/src/api/methods.js
@@ -1,4 +1,4 @@
-[
+module.exports = [
   {
     "api": "database_api",
     "method": "set_subscribe_callback",
@@ -492,4 +492,4 @@
     "method": "get_market_history_buckets",
     "params": []
   }
-]
+];

--- a/src/broadcast/index.js
+++ b/src/broadcast/index.js
@@ -3,7 +3,7 @@ import newDebug from 'debug';
 
 import broadcastHelpers from './helpers';
 import formatterFactory from '../formatter';
-import operations from './operations.json';
+import operations from './operations';
 import steemApi from '../api';
 import steemAuth from '../auth';
 import { camelCase } from '../utils';

--- a/src/broadcast/operations.js
+++ b/src/broadcast/operations.js
@@ -1,4 +1,4 @@
-[
+module.exports = [
   {
     "roles": ["posting"],
     "operation": "vote",
@@ -493,4 +493,4 @@
       "memo"
     ]
   }
-]
+];


### PR DESCRIPTION
So users don't need `json-loader` and `.json` as a detected module extension.