### PR TITLE
Add & remove a key in key_auth

### DIFF
--- a/examples/add-key-auth.js
+++ b/examples/add-key-auth.js
@@ -7,7 +7,7 @@ const privActiveWif = steem.auth.toWif(username, password, 'active');
 
 /** Add posting key auth */
 steem.broadcast.addKeyAuth({
-    activeWif: privActiveWif,
+    signingKey: privActiveWif,
     username,
     authorizedKey: 'STM88CPfhCmeEzCnvC1Cjc3DNd1DTjkMcmihih8SSxmm4LBqRq5Y9',
     role: 'posting',

--- a/examples/add-key-auth.js
+++ b/examples/add-key-auth.js
@@ -1,0 +1,22 @@
+const steem = require('../lib');
+
+/* Generate private active WIF */
+const username = process.env.STEEM_USERNAME;
+const password = process.env.STEEM_PASSWORD;
+const privActiveWif = steem.auth.toWif(username, password, 'active');
+
+/* Output public active WIF */
+//const pubActiveWif = steem.auth.wifToPublic(privActiveWif);
+//console.log(pubActiveWif);
+
+/* Add posting key auth */
+steem.broadcast.addKeyAuth(
+  privActiveWif,
+  username,
+  'STM88CPfhCmeEzCnvC1Cjc3DNd1DTjkMcmihih8SSxmm4LBqRq5Y9', // @fabien public posting WIF
+  'posting',
+  1,
+  (err, result) => {
+    console.log(err, result);
+  }
+);

--- a/examples/add-key-auth.js
+++ b/examples/add-key-auth.js
@@ -5,17 +5,13 @@ const username = process.env.STEEM_USERNAME;
 const password = process.env.STEEM_PASSWORD;
 const privActiveWif = steem.auth.toWif(username, password, 'active');
 
-/* Output public active WIF */
-//const pubActiveWif = steem.auth.wifToPublic(privActiveWif);
-//console.log(pubActiveWif);
-
-/* Add posting key auth */
-steem.broadcast.addKeyAuth(
-  privActiveWif,
-  username,
-  'STM88CPfhCmeEzCnvC1Cjc3DNd1DTjkMcmihih8SSxmm4LBqRq5Y9', // @fabien public posting WIF
-  'posting',
-  1,
+/** Add posting key auth */
+steem.broadcast.addKeyAuth({
+    activeWif: privActiveWif,
+    username,
+    authorizedKey: 'STM88CPfhCmeEzCnvC1Cjc3DNd1DTjkMcmihih8SSxmm4LBqRq5Y9',
+    role: 'posting',
+  },
   (err, result) => {
     console.log(err, result);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steem",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Steem.js the JavaScript API for Steem blockchain",
   "main": "lib/index.js",
   "scripts": {

--- a/src/auth/serializer/src/types.js
+++ b/src/auth/serializer/src/types.js
@@ -894,8 +894,8 @@ Types.public_key = {
         return object.toString()
     },
     compare(a, b) {
-        // sort decending
-        return -1 * strCmp(a.toString(), b.toString())
+        // sort ascending
+        return 1 * strCmp(a.toString(), b.toString())
     }
 };
 

--- a/src/broadcast/helpers.js
+++ b/src/broadcast/helpers.js
@@ -10,8 +10,8 @@ exports = module.exports = steemBroadcast => {
     cb
   ) => {
     api.getAccounts([username], (err, [userAccount]) => {
-      if (err) { return cb(err, null); }
-      if (!userAccount) { return cb('Invalid account name', null); }
+      if (err) { return cb(new Error(err), null); }
+      if (!userAccount) { return cb(new Error('Invalid account name'), null); }
 
       const updatedAuthority = userAccount[role];
 
@@ -49,8 +49,8 @@ exports = module.exports = steemBroadcast => {
     cb
   ) => {
     api.getAccounts([username], (err, [userAccount]) => {
-      if (err) { return cb(err, null); }
-      if (!userAccount) { return cb('Invalid account name', null); }
+      if (err) { return cb(new Error(err), null); }
+      if (!userAccount) { return cb(new Error('Invalid account name'), null); }
 
       const updatedAuthority = userAccount[role];
       const totalAuthorizedUser = updatedAuthority.account_auths.length;
@@ -93,8 +93,8 @@ exports = module.exports = steemBroadcast => {
     cb
   ) => {
     api.getAccounts([username], (err, [userAccount]) => {
-      if (err) { return cb(err, null); }
-      if (!userAccount) { return cb('Invalid account name', null); }
+      if (err) { return cb(new Error(err), null); }
+      if (!userAccount) { return cb(new Error('Invalid account name'), null); }
 
       const updatedAuthority = userAccount[role];
 
@@ -132,8 +132,8 @@ exports = module.exports = steemBroadcast => {
     cb
   ) => {
     api.getAccounts([username], (err, [userAccount]) => {
-      if (err) { return cb(err, null); }
-      if (!userAccount) { return cb('Invalid account name', null); }
+      if (err) { return cb(new Error(err), null); }
+      if (!userAccount) { return cb(new Error('Invalid account name'), null); }
 
       const updatedAuthority = userAccount[role];
       const totalAuthorizedKey = updatedAuthority.key_auths.length;

--- a/src/broadcast/helpers.js
+++ b/src/broadcast/helpers.js
@@ -1,14 +1,7 @@
 import api from '../api';
 
 exports = module.exports = steemBroadcast => {
-  steemBroadcast.addAccountAuth = (
-    activeWif,
-    username,
-    authorizedUsername,
-    role = 'posting',
-    weight = 1,
-    cb
-  ) => {
+  steemBroadcast.addAccountAuth = ({ activeWif, username, authorizedUsername, role = 'posting', weight }, cb) => {
     api.getAccounts([username], (err, [userAccount]) => {
       if (err) { return cb(new Error(err), null); }
       if (!userAccount) { return cb(new Error('Invalid account name'), null); }
@@ -41,13 +34,7 @@ exports = module.exports = steemBroadcast => {
     });
   };
 
-  steemBroadcast.removeAccountAuth = (
-    activeWif,
-    username,
-    authorizedUsername,
-    role = 'posting',
-    cb
-  ) => {
+  steemBroadcast.removeAccountAuth = ({ activeWif, username, authorizedUsername, role = 'posting' }, cb) => {
     api.getAccounts([username], (err, [userAccount]) => {
       if (err) { return cb(new Error(err), null); }
       if (!userAccount) { return cb(new Error('Invalid account name'), null); }
@@ -84,14 +71,7 @@ exports = module.exports = steemBroadcast => {
     });
   };
 
-  steemBroadcast.addKeyAuth = (
-    activeWif,
-    username,
-    authorizedKey,
-    role = 'posting',
-    weight = 1,
-    cb
-  ) => {
+  steemBroadcast.addKeyAuth = ({ activeWif, username, authorizedKey, role = 'posting', weight }, cb) => {
     api.getAccounts([username], (err, [userAccount]) => {
       if (err) { return cb(new Error(err), null); }
       if (!userAccount) { return cb(new Error('Invalid account name'), null); }
@@ -124,13 +104,7 @@ exports = module.exports = steemBroadcast => {
     });
   };
 
-  steemBroadcast.removeKeyAuth = (
-    activeWif,
-    username,
-    authorizedKey,
-    role = 'posting',
-    cb
-  ) => {
+  steemBroadcast.removeKeyAuth = ({ activeWif, username, authorizedKey, role = 'posting' }, cb) => {
     api.getAccounts([username], (err, [userAccount]) => {
       if (err) { return cb(new Error(err), null); }
       if (!userAccount) { return cb(new Error('Invalid account name'), null); }

--- a/src/broadcast/helpers.js
+++ b/src/broadcast/helpers.js
@@ -14,16 +14,14 @@ exports = module.exports = steemBroadcast => {
       if (!userAccount) { return cb('Invalid account name', null); }
 
       const updatedAuthority = userAccount[role];
-      const authorizedAccounts = updatedAuthority.account_auths.map(
-        auth => auth[0]
-      );
-      const hasAuthority =
-        authorizedAccounts.indexOf(authorizedUsername) !== -1;
 
+      /** Release callback if the account already exist in the account_auths array */
+      const authorizedAccounts = updatedAuthority.account_auths.map(auth => auth[0]);
+      const hasAuthority = authorizedAccounts.indexOf(authorizedUsername) !== -1;
       if (hasAuthority) {
-        // user does already exist in authorized list
         return cb(null, null);
       }
+
       updatedAuthority.account_auths.push([authorizedUsername, weight]);
       const owner = role === 'owner' ? updatedAuthority : undefined;
       const active = role === 'active' ? updatedAuthority : undefined;
@@ -64,7 +62,7 @@ exports = module.exports = steemBroadcast => {
         }
       }
 
-      // user does not exist in authorized list
+      /** Release callback if the account does not exist in the account_auths array */
       if (totalAuthorizedUser === updatedAuthority.account_auths.length) {
         return cb(null, null);
       }
@@ -99,16 +97,14 @@ exports = module.exports = steemBroadcast => {
       if (!userAccount) { return cb('Invalid account name', null); }
 
       const updatedAuthority = userAccount[role];
-      const authorizedKeys = updatedAuthority.key_auths.map(
-        auth => auth[0]
-      );
-      const hasAuthority =
-        authorizedKeys.indexOf(authorizedKey) !== -1;
 
+      /** Release callback if the key already exist in the key_auths array */
+      const authorizedKeys = updatedAuthority.key_auths.map(auth => auth[0]);
+      const hasAuthority = authorizedKeys.indexOf(authorizedKey) !== -1;
       if (hasAuthority) {
-        // key already exist in authorized list
         return cb(null, null);
       }
+
       updatedAuthority.key_auths.push([authorizedKey, weight]);
       const owner = role === 'owner' ? updatedAuthority : undefined;
       const active = role === 'active' ? updatedAuthority : undefined;
@@ -149,7 +145,7 @@ exports = module.exports = steemBroadcast => {
         }
       }
 
-      // key not exist in authorized list
+      /** Release callback if the key does not exist in the key_auths array */
       if (totalAuthorizedKey === updatedAuthority.key_auths.length) {
         return cb(null, null);
       }

--- a/src/broadcast/helpers.js
+++ b/src/broadcast/helpers.js
@@ -1,7 +1,7 @@
 import api from '../api';
 
 exports = module.exports = steemBroadcast => {
-  steemBroadcast.addAccountAuth = ({ activeWif, username, authorizedUsername, role = 'posting', weight }, cb) => {
+  steemBroadcast.addAccountAuth = ({ signingKey, username, authorizedUsername, role = 'posting', weight }, cb) => {
     api.getAccounts([username], (err, [userAccount]) => {
       if (err) { return cb(new Error(err), null); }
       if (!userAccount) { return cb(new Error('Invalid account name'), null); }
@@ -24,7 +24,7 @@ exports = module.exports = steemBroadcast => {
 
       /** Add authority on user account */
       steemBroadcast.accountUpdate(
-        activeWif,
+        signingKey,
         userAccount.name,
         owner,
         active,
@@ -36,7 +36,7 @@ exports = module.exports = steemBroadcast => {
     });
   };
 
-  steemBroadcast.removeAccountAuth = ({ activeWif, username, authorizedUsername, role = 'posting' }, cb) => {
+  steemBroadcast.removeAccountAuth = ({ signingKey, username, authorizedUsername, role = 'posting' }, cb) => {
     api.getAccounts([username], (err, [userAccount]) => {
       if (err) { return cb(new Error(err), null); }
       if (!userAccount) { return cb(new Error('Invalid account name'), null); }
@@ -61,7 +61,7 @@ exports = module.exports = steemBroadcast => {
       const posting = role === 'posting' ? updatedAuthority : undefined;
 
       steemBroadcast.accountUpdate(
-        activeWif,
+        signingKey,
         userAccount.name,
         owner,
         active,
@@ -73,7 +73,7 @@ exports = module.exports = steemBroadcast => {
     });
   };
 
-  steemBroadcast.addKeyAuth = ({ activeWif, username, authorizedKey, role = 'posting', weight }, cb) => {
+  steemBroadcast.addKeyAuth = ({ signingKey, username, authorizedKey, role = 'posting', weight }, cb) => {
     api.getAccounts([username], (err, [userAccount]) => {
       if (err) { return cb(new Error(err), null); }
       if (!userAccount) { return cb(new Error('Invalid account name'), null); }
@@ -96,7 +96,7 @@ exports = module.exports = steemBroadcast => {
 
       /** Add authority on user account */
       steemBroadcast.accountUpdate(
-        activeWif,
+        signingKey,
         userAccount.name,
         owner,
         active,
@@ -108,7 +108,7 @@ exports = module.exports = steemBroadcast => {
     });
   };
 
-  steemBroadcast.removeKeyAuth = ({ activeWif, username, authorizedKey, role = 'posting' }, cb) => {
+  steemBroadcast.removeKeyAuth = ({ signingKey, username, authorizedKey, role = 'posting' }, cb) => {
     api.getAccounts([username], (err, [userAccount]) => {
       if (err) { return cb(new Error(err), null); }
       if (!userAccount) { return cb(new Error('Invalid account name'), null); }
@@ -133,7 +133,7 @@ exports = module.exports = steemBroadcast => {
       const posting = role === 'posting' ? updatedAuthority : undefined;
 
       steemBroadcast.accountUpdate(
-        activeWif,
+        signingKey,
         userAccount.name,
         owner,
         active,

--- a/src/broadcast/helpers.js
+++ b/src/broadcast/helpers.js
@@ -9,7 +9,10 @@ exports = module.exports = steemBroadcast => {
     weight = 1,
     cb
   ) => {
-    api.getAccountsAsync([username]).then(([userAccount]) => {
+    api.getAccounts([username], (err, [userAccount]) => {
+      if (err) { return cb(err, null); }
+      if (!userAccount) { return cb('Invalid account name', null); }
+
       const updatedAuthority = userAccount[role];
       const authorizedAccounts = updatedAuthority.account_auths.map(
         auth => auth[0]
@@ -47,7 +50,10 @@ exports = module.exports = steemBroadcast => {
     role = 'posting',
     cb
   ) => {
-    api.getAccountsAsync([username]).then(([userAccount]) => {
+    api.getAccounts([username], (err, [userAccount]) => {
+      if (err) { return cb(err, null); }
+      if (!userAccount) { return cb('Invalid account name', null); }
+
       const updatedAuthority = userAccount[role];
       const totalAuthorizedUser = updatedAuthority.account_auths.length;
       for (let i = 0; i < totalAuthorizedUser; i++) {
@@ -88,7 +94,10 @@ exports = module.exports = steemBroadcast => {
     weight = 1,
     cb
   ) => {
-    api.getAccountsAsync([username]).then(([userAccount]) => {
+    api.getAccounts([username], (err, [userAccount]) => {
+      if (err) { return cb(err, null); }
+      if (!userAccount) { return cb('Invalid account name', null); }
+
       const updatedAuthority = userAccount[role];
       const authorizedKeys = updatedAuthority.key_auths.map(
         auth => auth[0]
@@ -126,7 +135,10 @@ exports = module.exports = steemBroadcast => {
     role = 'posting',
     cb
   ) => {
-    api.getAccountsAsync([username]).then(([userAccount]) => {
+    api.getAccounts([username], (err, [userAccount]) => {
+      if (err) { return cb(err, null); }
+      if (!userAccount) { return cb('Invalid account name', null); }
+
       const updatedAuthority = userAccount[role];
       const totalAuthorizedKey = updatedAuthority.key_auths.length;
       for (let i = 0; i < totalAuthorizedKey; i++) {

--- a/src/broadcast/helpers.js
+++ b/src/broadcast/helpers.js
@@ -1,13 +1,12 @@
-import api from "../api";
-
-const defaultWeight = 1;
+import api from '../api';
 
 exports = module.exports = steemBroadcast => {
   steemBroadcast.addAccountAuth = (
     activeWif,
     username,
     authorizedUsername,
-    role = "posting",
+    role = 'posting',
+    weight = 1,
     cb
   ) => {
     api.getAccountsAsync([username]).then(([userAccount]) => {
@@ -22,10 +21,11 @@ exports = module.exports = steemBroadcast => {
         // user does already exist in authorized list
         return cb(null, null);
       }
-      updatedAuthority.account_auths.push([authorizedUsername, defaultWeight]);
-      const owner = role === "owner" ? updatedAuthority : undefined;
-      const active = role === "active" ? updatedAuthority : undefined;
-      const posting = role === "posting" ? updatedAuthority : undefined;
+      updatedAuthority.account_auths.push([authorizedUsername, weight]);
+      const owner = role === 'owner' ? updatedAuthority : undefined;
+      const active = role === 'active' ? updatedAuthority : undefined;
+      const posting = role === 'posting' ? updatedAuthority : undefined;
+
       /** Add authority on user account */
       steemBroadcast.accountUpdate(
         activeWif,
@@ -44,7 +44,7 @@ exports = module.exports = steemBroadcast => {
     activeWif,
     username,
     authorizedUsername,
-    role = "posting",
+    role = 'posting',
     cb
   ) => {
     api.getAccountsAsync([username]).then(([userAccount]) => {
@@ -57,14 +57,94 @@ exports = module.exports = steemBroadcast => {
           break;
         }
       }
+
       // user does not exist in authorized list
       if (totalAuthorizedUser === updatedAuthority.account_auths.length) {
         return cb(null, null);
       }
 
-      const owner = role === "owner" ? updatedAuthority : undefined;
-      const active = role === "active" ? updatedAuthority : undefined;
-      const posting = role === "posting" ? updatedAuthority : undefined;
+      const owner = role === 'owner' ? updatedAuthority : undefined;
+      const active = role === 'active' ? updatedAuthority : undefined;
+      const posting = role === 'posting' ? updatedAuthority : undefined;
+
+      steemBroadcast.accountUpdate(
+        activeWif,
+        userAccount.name,
+        owner,
+        active,
+        posting,
+        userAccount.memo_key,
+        userAccount.json_metadata,
+        cb
+      );
+    });
+  };
+
+  steemBroadcast.addKeyAuth = (
+    activeWif,
+    username,
+    authorizedKey,
+    role = 'posting',
+    weight = 1,
+    cb
+  ) => {
+    api.getAccountsAsync([username]).then(([userAccount]) => {
+      const updatedAuthority = userAccount[role];
+      const authorizedKeys = updatedAuthority.key_auths.map(
+        auth => auth[0]
+      );
+      const hasAuthority =
+        authorizedKeys.indexOf(authorizedKey) !== -1;
+
+      if (hasAuthority) {
+        // key already exist in authorized list
+        return cb(null, null);
+      }
+      updatedAuthority.key_auths.push([authorizedKey, weight]);
+      const owner = role === 'owner' ? updatedAuthority : undefined;
+      const active = role === 'active' ? updatedAuthority : undefined;
+      const posting = role === 'posting' ? updatedAuthority : undefined;
+
+      /** Add authority on user account */
+      steemBroadcast.accountUpdate(
+        activeWif,
+        userAccount.name,
+        owner,
+        active,
+        posting,
+        userAccount.memo_key,
+        userAccount.json_metadata,
+        cb
+      );
+    });
+  };
+
+  steemBroadcast.removeKeyAuth = (
+    activeWif,
+    username,
+    authorizedKey,
+    role = 'posting',
+    cb
+  ) => {
+    api.getAccountsAsync([username]).then(([userAccount]) => {
+      const updatedAuthority = userAccount[role];
+      const totalAuthorizedKey = updatedAuthority.key_auths.length;
+      for (let i = 0; i < totalAuthorizedKey; i++) {
+        const user = updatedAuthority.key_auths[i];
+        if (user[0] === authorizedKey) {
+          updatedAuthority.key_auths.splice(i, 1);
+          break;
+        }
+      }
+
+      // key not exist in authorized list
+      if (totalAuthorizedKey === updatedAuthority.key_auths.length) {
+        return cb(null, null);
+      }
+
+      const owner = role === 'owner' ? updatedAuthority : undefined;
+      const active = role === 'active' ? updatedAuthority : undefined;
+      const posting = role === 'posting' ? updatedAuthority : undefined;
 
       steemBroadcast.accountUpdate(
         activeWif,

--- a/src/broadcast/helpers.js
+++ b/src/broadcast/helpers.js
@@ -15,6 +15,8 @@ exports = module.exports = steemBroadcast => {
         return cb(null, null);
       }
 
+      /** Use weight_thresold as default weight */
+      weight = weight || userAccount[role].weight_threshold;
       updatedAuthority.account_auths.push([authorizedUsername, weight]);
       const owner = role === 'owner' ? updatedAuthority : undefined;
       const active = role === 'active' ? updatedAuthority : undefined;
@@ -85,6 +87,8 @@ exports = module.exports = steemBroadcast => {
         return cb(null, null);
       }
 
+      /** Use weight_thresold as default weight */
+      weight = weight || userAccount[role].weight_threshold;
       updatedAuthority.key_auths.push([authorizedKey, weight]);
       const owner = role === 'owner' ? updatedAuthority : undefined;
       const active = role === 'active' ? updatedAuthority : undefined;

--- a/test/types_test.js
+++ b/test/types_test.js
@@ -53,13 +53,13 @@ describe("steem.auth: types", function() {
     it("public_key sort", function() {
         let mapType = type.map(type.public_key, type.uint16)
         let map = mapType.fromObject([//not sorted
-            ["STM56ankGHKf6qUsQe7vPsXTSEqST6Dt1ff73aV3YQbedzRua8NLQ",0],
-            ["STM8me6d9PqzTgcoHxx6b4rnvWVTqz11kafidRAZwfacJkcJtfd75",0],
+          ["STM8me6d9PqzTgcoHxx6b4rnvWVTqz11kafidRAZwfacJkcJtfd75",0],
+          ["STM56ankGHKf6qUsQe7vPsXTSEqST6Dt1ff73aV3YQbedzRua8NLQ",0],
         ])
         let mapObject = mapType.toObject(map)
         assert.deepEqual(mapObject, [ // sorted (uppercase comes first)
-            ["STM8me6d9PqzTgcoHxx6b4rnvWVTqz11kafidRAZwfacJkcJtfd75",0],
             ["STM56ankGHKf6qUsQe7vPsXTSEqST6Dt1ff73aV3YQbedzRua8NLQ",0],
+            ["STM8me6d9PqzTgcoHxx6b4rnvWVTqz11kafidRAZwfacJkcJtfd75",0],
         ])
     })
 


### PR DESCRIPTION
I have some trouble making this working and interested to have your feedback.

I created 2 helpers functions: `addKeyAuth` and `removeKeyAuth` for adding and removing a key inside user account `key_auths` array. It's using the operation `account_update` to do this change (https://github.com/steemit/steem-js/blob/d81a9a3a0f22cabc9a81fd8843801fdf980ecf08/src/broadcast/helpers.js#L109-L118) .

We have already the helpers functions `addAccountAuth` and `removeAccountAuth` that working well, but for some reason when i try to add a key instead of an account i got the error "Missing Active Authority". I've verified the private active WIF and account_update operation payload and they are valid.

Any idea what is wrong?