### PR TITLE
Set transport with url

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
   "transport": "ws",
   "websocket": "wss://steemd.steemit.com",
   "uri": "https://steemd.steemit.com",
+  "url": "wss://steemd.steemit.com",
   "dev_uri": "https://steemd.steemitdev.com",
   "stage_uri": "https://steemd.steemitstage.com",
   "address_prefix": "STM",

--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   "transport": "ws",
   "websocket": "wss://steemd.steemit.com",
   "uri": "https://steemd.steemit.com",
-  "url": false,
+  "url": "",
   "dev_uri": "https://steemd.steemitdev.com",
   "stage_uri": "https://steemd.steemitstage.com",
   "address_prefix": "STM",

--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   "transport": "ws",
   "websocket": "wss://steemd.steemit.com",
   "uri": "https://steemd.steemit.com",
-  "url": "wss://steemd.steemit.com",
+  "url": false,
   "dev_uri": "https://steemd.steemitdev.com",
   "stage_uri": "https://steemd.steemitstage.com",
   "address_prefix": "STM",

--- a/doc/README.md
+++ b/doc/README.md
@@ -42,7 +42,7 @@ steem.api.getAccounts(['ned', 'dan'], function(err, response){
 Default config should work with steem. however you can change it to work with golos
 as 
 ```js
-steem.config.set('websocket','wss://ws.golos.io'); // assuming websocket is work at ws.golos.io
+steem.api.setOptions({ url: 'wss://ws.golos.io' }); // assuming websocket is work at ws.golos.io
 steem.config.set('address_prefix','GLS');
 steem.config.set('chain_id','782a3039b478c839e4cb0c941ff4eaeb7df40bdd68bd441afd444b9da763de12');
 ```
@@ -58,11 +58,7 @@ steem.config.get('chain_id');
 ## JSON-RPC
 Here is how to activate JSON-RPC transport:
 ```js
-steem.api.setOptions({
-  transport: 'http',
-  uri: 'https://steemd.steemitdev.com' // Optional, by default https://steemd.steemit.com is used.
-});
-
+steem.api.setOptions({ url: 'https://steemd.steemit.com' });
 ```
 
 # API

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build-browser": "rm -rf dist && NODE_ENV=production webpack && gzip -k -f ./dist/*.js && du -h ./dist/*",
     "build-node": "mkdir -p ./lib && cp -r ./src/* ./lib/ && babel ./src --out-dir ./lib",
     "prepublish": "npm run build",
-    "postinstall": "cross-env scripts/post-install.js"
+    "postinstall": "node node_modules/cross-env/dist/bin/cross-env.js scripts/post-install.js"
   },
   "browser": {
     "ws": false,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build-node": "mkdir -p ./lib && cp -r ./src/* ./lib/ && babel ./src --out-dir ./lib",
     "prepublish": "npm run build",
     "prepare": "npm run build",
-    "postinstall": "cross-env scripts/post-install.js"
+    "postinstall": "npm run build && cross-env scripts/post-install.js"
   },
   "browser": {
     "ws": false,

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "build-browser": "rm -rf dist && NODE_ENV=production webpack && gzip -k -f ./dist/*.js && du -h ./dist/*",
     "build-node": "mkdir -p ./lib && cp -r ./src/* ./lib/ && babel ./src --out-dir ./lib",
     "prepublish": "npm run build",
-    "prepare": "npm run build",
-    "postinstall": "npm run build && cross-env scripts/post-install.js"
+    "postinstall": "postinstall-build lib && cross-env scripts/post-install.js"
   },
   "browser": {
     "ws": false,
@@ -48,6 +47,7 @@
     "ecurve": "^1.0.5",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.16.4",
+    "postinstall-build": "^5.0.1",
     "secure-random": "^1.1.1",
     "ws": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build-browser": "rm -rf dist && NODE_ENV=production webpack && gzip -k -f ./dist/*.js && du -h ./dist/*",
     "build-node": "mkdir -p ./lib && cp -r ./src/* ./lib/ && babel ./src --out-dir ./lib",
     "prepublish": "npm run build",
-    "postinstall": "node node_modules/cross-env/dist/bin/cross-env.js scripts/post-install.js"
+    "prepare": "npm run build",
+    "postinstall": "cross-env scripts/post-install.js"
   },
   "browser": {
     "ws": false,

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -38,7 +38,8 @@ class Steem extends EventEmitter {
           this.transport = new transports.http(options);
         }
         else {
-          this.websocket = this.uri;
+          if(this.uri)
+            this.websocket = this.uri;
           this.transport = new transports.ws(options);
         }
     }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -18,11 +18,17 @@ class Steem extends EventEmitter {
     if(options.url.match('^((http|https)?:\/\/)'))
     {
       options.uri = options.url;
+      options.transport = 'http';
+      this._transportType = options.transport;
+      this.options = options;
       this.transport = new transports.http(options);
     }
     else if(options.url.match('^((ws|wss)?:\/\/)'))
     {
       options.websocket = options.url;
+      options.transport = 'ws';
+      this._transportType = options.transport;
+      this.options = options;
       this.transport = new transports.ws(options);
     }
     else if (options.transport) 

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -15,33 +15,43 @@ class Steem extends EventEmitter {
   }
 
   _setTransport(options) {
-    if (options.transport) {
-      if (this.transport && this._transportType !== options.transport) {
+    if(options.url.match('^((http|https)?:\/\/)'))
+    {
+      options.uri = options.url;
+      this.transport = new transports.http(options);
+    }
+    else if(options.url.match('^((ws|wss)?:\/\/)'))
+    {
+      options.websocket = options.url;
+      this.transport = new transports.ws(options);
+    }
+    else if (options.transport) 
+    {
+      if (this.transport && this._transportType !== options.transport)
+      {
         this.transport.stop();
       }
 
       this._transportType = options.transport;
 
-      if (typeof options.transport === 'string') {
-        if (!transports[options.transport]) {
+      if (typeof options.transport === 'string')
+      {
+        if (!transports[options.transport])
+        {
           throw new TypeError(
             'Invalid `transport`, valid values are `http`, `ws` or a class',
           );
         }
         this.transport = new transports[options.transport](options);
-      } else {
+      } 
+      else 
+      {
         this.transport = new options.transport(options);
       }
-    } else {
-        if(options.uri.match('^((http|https)?:\/\/)'))
-        {
-          this.transport = new transports.http(options);
-        }
-        else {
-          if(options.uri)
-            options.websocket = options.uri;
-          this.transport = new transports.ws(options);
-        }
+    } 
+    else
+    {
+        this.transport = new transports.ws(options);
     }
   }
 

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -33,7 +33,14 @@ class Steem extends EventEmitter {
         this.transport = new options.transport(options);
       }
     } else {
-      this.transport = new transports.ws(options);
+        if(options.uri.match('^(http|https)://'))
+        {
+          this.transport = new transports.http(options);
+        }
+        else {
+          this.websocket = this.uri;
+          this.transport = new transports.ws(options);
+        }
     }
   }
 

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -33,13 +33,13 @@ class Steem extends EventEmitter {
         this.transport = new options.transport(options);
       }
     } else {
-        if(options.uri.match('^(http|https)://'))
+        if(options.uri.match('^((http|https)?:\/\/)'))
         {
           this.transport = new transports.http(options);
         }
         else {
-          if(this.uri)
-            this.websocket = this.uri;
+          if(options.uri)
+            options.websocket = options.uri;
           this.transport = new transports.ws(options);
         }
     }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,39 +1,37 @@
 require('babel-polyfill');
 import assert from 'assert';
 import should from 'should';
-import config from '../src/config';
 import testPost from './test-post.json';
-import api from '../src/api';
+import steem from '../src';
 
 describe('steem.api:', function () {
   this.timeout(30 * 1000);
 
-  describe('setUri', () => {
+  describe('setOptions', () => {
     it('works', () => {
-      // api.setUri('http://localhost');
-      config.set('uri', config.get('dev_uri'));
+      steem.api.setOptions({ url: steem.config.get('websocket') });
     });
   });
 
   describe('getFollowers', () => {
     describe('getting ned\'s followers', () => {
       it('works', async () => {
-        const result = await api.getFollowersAsync('ned', 0, 'blog', 5);
+        const result = await steem.api.getFollowersAsync('ned', 0, 'blog', 5);
         assert(result, 'getFollowersAsync resoved to null?');
         result.should.have.lengthOf(5);
       });
 
       it('the startFollower parameter has an impact on the result', async () => {
         // Get the first 5
-        const result1 = await api.getFollowersAsync('ned', 0, 'blog', 5)
+        const result1 = await steem.api.getFollowersAsync('ned', 0, 'blog', 5)
           result1.should.have.lengthOf(5);
-        const result2 = await api.getFollowersAsync('ned', result1[result1.length - 1].follower, 'blog', 5)
+        const result2 = await steem.api.getFollowersAsync('ned', result1[result1.length - 1].follower, 'blog', 5)
           result2.should.have.lengthOf(5);
         result1.should.not.be.eql(result2);
       });
 
       it('clears listeners', async () => {
-        api.listeners('message').should.have.lengthOf(0);
+        steem.api.listeners('message').should.have.lengthOf(0);
       });
     });
   });
@@ -41,12 +39,12 @@ describe('steem.api:', function () {
   describe('getContent', () => {
     describe('getting a random post', () => {
       it('works', async () => {
-        const result = await api.getContentAsync('yamadapc', 'test-1-2-3-4-5-6-7-9');
+        const result = await steem.api.getContentAsync('yamadapc', 'test-1-2-3-4-5-6-7-9');
         result.should.have.properties(testPost);
       });
 
       it('clears listeners', async () => {
-        api.listeners('message').should.have.lengthOf(0);
+        steem.api.listeners('message').should.have.lengthOf(0);
       });
     });
   });
@@ -54,7 +52,7 @@ describe('steem.api:', function () {
   describe('streamBlockNumber', () => {
     it('streams steem transactions', (done) => {
       let i = 0;
-      const release = api.streamBlockNumber((err, block) => {
+      const release = steem.api.streamBlockNumber((err, block) => {
         should.exist(block);
         block.should.be.instanceOf(Number);
         i++;
@@ -69,7 +67,7 @@ describe('steem.api:', function () {
   describe('streamBlock', () => {
     it('streams steem blocks', (done) => {
       let i = 0;
-      const release = api.streamBlock((err, block) => {
+      const release = steem.api.streamBlock((err, block) => {
         try {
           should.exist(block);
           block.should.have.properties([
@@ -95,7 +93,7 @@ describe('steem.api:', function () {
   describe('streamTransactions', () => {
     it('streams steem transactions', (done) => {
       let i = 0;
-      const release = api.streamTransactions((err, transaction) => {
+      const release = steem.api.streamTransactions((err, transaction) => {
         try {
           should.exist(transaction);
           transaction.should.have.properties([
@@ -121,7 +119,7 @@ describe('steem.api:', function () {
   describe('streamOperations', () => {
     it('streams steem operations', (done) => {
       let i = 0;
-      const release = api.streamOperations((err, operation) => {
+      const release = steem.api.streamOperations((err, operation) => {
         try {
           should.exist(operation);
         } catch (err2) {


### PR DESCRIPTION
This allows for setting the transport with a new configuration option `url`. It will leave the original methods of initiating steem-js intact to not break functionality for current users. Also, this adds the post-install build script npm module which makes it possible to load steem-js directly from a git url instead of from npm.