### PR TITLE
Use old api syntax for JSON-RPC

### DIFF
--- a/src/api/transports/http.js
+++ b/src/api/transports/http.js
@@ -12,8 +12,8 @@ export default class HttpTransport extends Transport {
     const payload = {
       id,
       jsonrpc: '2.0',
-      method: data.method,
-      params: data.params,
+      method: 'call',
+      params: [api, data.method, data.params],
     };
     fetch(this.options.uri, {
       method: 'POST',


### PR DESCRIPTION
It's not possible for the moment to specify the api name using the new syntax and make it impossible to broadcast a tx see related issue: https://github.com/steemit/steem/issues/1282. I revert changes on the syntax to enable back broadcast API with JSON-RPC.