### PR TITLE
Fix params get_content_replies

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -419,7 +419,7 @@ steem.api.getContent(author, permlink, function(err, result) {
 ```
 ### Get Content Replies
 ```
-steem.api.getContentReplies(parent, parentPermlink, function(err, result) {
+steem.api.getContentReplies(author, permlink, function(err, result) {
   console.log(err, result);
 });
 ```

--- a/src/api/methods.js
+++ b/src/api/methods.js
@@ -312,7 +312,7 @@ module.exports = [
   {
     "api": "database_api",
     "method": "get_content_replies",
-    "params": ["parent", "parentPermlink"]
+    "params": ["author", "permlink"]
   },
   {
     "api": "database_api",


### PR DESCRIPTION
Steem REST API (api.steemjs.com) rely on steem-js file `src/api/methods.js` to parse parameters. The request `https://api.steemjs.com/get_content_replies?author=siol&permlink=test` was failing because params were wrong in steem-js mapping