### PR TITLE
fix condenser build with node 8.5 and webpack 1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "eslint --quiet src test; mocha -t 20000 --require babel-polyfill --require babel-register",
     "test-auth": "npm test -- --grep 'steem.auth'",
     "build": "npm run build-browser && npm run build-node",
-    "build-browser": "rm -rf dist && NODE_ENV=production webpack && gzip -k -f ./dist/*.js && du -h ./dist/*",
+    "build-browser": "rm -rf dist && NODE_ENV=production node ./node_modules/webpack/bin/webpack.js && gzip -k -f ./dist/*.js && du -h ./dist/*",
     "build-node": "mkdir -p ./lib && cp -r ./src/* ./lib/ && babel ./src --out-dir ./lib",
     "prepublish": "npm run build",
     "postinstall": "postinstall-build lib && cross-env scripts/post-install.js"

--- a/webpack/makeConfig.js
+++ b/webpack/makeConfig.js
@@ -84,7 +84,6 @@ function makeConfig(options) {
       loaders: [
         {
           test: /\.js?$/,
-          exclude: /node_modules/,
           loader: 'babel',
         },
         {


### PR DESCRIPTION
When steem-js is located inside of node_modules of another project `exclude: /node_modules/` was  excluding all .js files not only local node_modules content, so it was failing to build.
I've checked it works without this exclude directive but I tested it only with node 8.5, probably more testing is needed.
I've also updated "build-browser" to always call local webpack to make sure the right version is called and there would no requirement for globally installed webpack.