### PR TITLE
websocket client can now switch to appBase

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
   "transport": "ws",
   "websocket": "wss://steemd.steemit.com",
+  "websocketdev": "wss://steemd.steemitdev.com",
   "uri": "https://steemd.steemit.com",
   "url": "",
   "dev_uri": "https://steemd.steemitdev.com",

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -43,10 +43,9 @@ class Steem extends EventEmitter {
                 return this[`${methodName}With`](options, callback);
             };
 
-	    this[`${methodName}WithAsync`] = Promise.promisify(this[`${methodName}With`]);
+	          this[`${methodName}WithAsync`] = Promise.promisify(this[`${methodName}With`]);
             this[`${methodName}Async`] = Promise.promisify(this[methodName]);
         });
-
     }
 
     _setTransport(options) {

--- a/src/api/methods.js
+++ b/src/api/methods.js
@@ -1,495 +1,495 @@
-module.exports = [
-  {
-    "api": "database_api",
-    "method": "set_subscribe_callback",
-    "params": ["callback", "clearFilter"]
-  },
-  {
-    "api": "database_api",
-    "method": "set_pending_transaction_callback",
-    "params": ["cb"]
-  },
-  {
-    "api": "database_api",
-    "method": "set_block_applied_callback",
-    "params": ["cb"]
-  },
-  {
-    "api": "database_api",
-    "method": "cancel_all_subscriptions"
-  },
-  {
-    "api": "database_api",
-    "method": "get_trending_tags",
-    "params": ["afterTag", "limit"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_tags_used_by_author",
-    "params": ["author"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_post_discussions_by_payout",
-    "params": ["query"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_comment_discussions_by_payout",
-    "params": ["query"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_discussions_by_trending",
-    "params": ["query"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_discussions_by_trending30",
-    "params": ["query"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_discussions_by_created",
-    "params": ["query"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_discussions_by_active",
-    "params": ["query"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_discussions_by_cashout",
-    "params": ["query"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_discussions_by_payout",
-    "params": ["query"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_discussions_by_votes",
-    "params": ["query"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_discussions_by_children",
-    "params": ["query"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_discussions_by_hot",
-    "params": ["query"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_discussions_by_feed",
-    "params": ["query"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_discussions_by_blog",
-    "params": ["query"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_discussions_by_comments",
-    "params": ["query"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_discussions_by_promoted",
-    "params": ["query"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_block_header",
-    "params": ["blockNum"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_block",
-    "params": ["blockNum"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_ops_in_block",
-    "params": ["blockNum", "onlyVirtual"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_state",
-    "params": ["path"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_trending_categories",
-    "params": ["after", "limit"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_best_categories",
-    "params": ["after", "limit"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_active_categories",
-    "params": ["after", "limit"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_recent_categories",
-    "params": ["after", "limit"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_config"
-  },
-  {
-    "api": "database_api",
-    "method": "get_dynamic_global_properties"
-  },
-  {
-    "api": "database_api",
-    "method": "get_chain_properties"
-  },
-  {
-    "api": "database_api",
-    "method": "get_feed_history"
-  },
-  {
-    "api": "database_api",
-    "method": "get_current_median_history_price"
-  },
-  {
-    "api": "database_api",
-    "method": "get_witness_schedule"
-  },
-  {
-    "api": "database_api",
-    "method": "get_hardfork_version"
-  },
-  {
-    "api": "database_api",
-    "method": "get_next_scheduled_hardfork"
-  },
-  {
-    "api": "account_by_key_api",
-    "method": "get_key_references",
-    "params": ["key"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_accounts",
-    "params": ["names"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_account_references",
-    "params": ["accountId"]
-  },
-  {
-    "api": "database_api",
-    "method": "lookup_account_names",
-    "params": ["accountNames"]
-  },
-  {
-    "api": "database_api",
-    "method": "lookup_accounts",
-    "params": ["lowerBoundName", "limit"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_account_count"
-  },
-  {
-    "api": "database_api",
-    "method": "get_conversion_requests",
-    "params": ["accountName"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_account_history",
-    "params": ["account", "from", "limit"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_owner_history",
-    "params": ["account"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_recovery_request",
-    "params": ["account"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_escrow",
-    "params": ["from", "escrowId"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_withdraw_routes",
-    "params": ["account", "withdrawRouteType"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_account_bandwidth",
-    "params": ["account", "bandwidthType"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_savings_withdraw_from",
-    "params": ["account"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_savings_withdraw_to",
-    "params": ["account"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_order_book",
-    "params": ["limit"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_open_orders",
-    "params": ["owner"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_liquidity_queue",
-    "params": ["startAccount", "limit"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_transaction_hex",
-    "params": ["trx"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_transaction",
-    "params": ["trxId"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_required_signatures",
-    "params": ["trx", "availableKeys"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_potential_signatures",
-    "params": ["trx"]
-  },
-  {
-    "api": "database_api",
-    "method": "verify_authority",
-    "params": ["trx"]
-  },
-  {
-    "api": "database_api",
-    "method": "verify_account_authority",
-    "params": ["nameOrId", "signers"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_active_votes",
-    "params": ["author", "permlink"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_account_votes",
-    "params": ["voter"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_content",
-    "params": ["author", "permlink"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_content_replies",
-    "params": ["author", "permlink"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_discussions_by_author_before_date",
-    "params": ["author", "startPermlink", "beforeDate", "limit"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_replies_by_last_update",
-    "params": ["startAuthor", "startPermlink", "limit"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_witnesses",
-    "params": ["witnessIds"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_witness_by_account",
-    "params": ["accountName"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_witnesses_by_vote",
-    "params": ["from", "limit"]
-  },
-  {
-    "api": "database_api",
-    "method": "lookup_witness_accounts",
-    "params": ["lowerBoundName", "limit"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_witness_count"
-  },
-  {
-    "api": "database_api",
-    "method": "get_active_witnesses"
-  },
-  {
-    "api": "database_api",
-    "method": "get_miner_queue"
-  },
-  {
-    "api": "database_api",
-    "method": "get_reward_fund",
-    "params": ["name"]
-  },
-  {
-    "api": "database_api",
-    "method": "get_vesting_delegations",
-    "params": ["account", "from", "limit"]
-  },
-  {
-    "api": "login_api",
-    "method": "login",
-    "params": ["username", "password"]
-  },
-  {
-    "api": "login_api",
-    "method": "get_api_by_name",
-    "params": ["apiName"]
-  },
-  {
-    "api": "login_api",
-    "method": "get_version"
-  },
-  {
-    "api": "follow_api",
-    "method": "get_followers",
-    "params": ["following", "startFollower", "followType", "limit"]
-  },
-  {
-    "api": "follow_api",
-    "method": "get_following",
-    "params": ["follower", "startFollowing", "followType", "limit"]
-  },
-  {
-    "api": "follow_api",
-    "method": "get_follow_count",
-    "params": ["account"]
-  },
-  {
-    "api": "follow_api",
-    "method": "get_feed_entries",
-    "params": ["account", "entryId", "limit"
-    ]
-  },
-  {
-    "api": "follow_api",
-    "method": "get_feed",
-    "params": ["account", "entryId", "limit"]
-  },
-  {
-    "api": "follow_api",
-    "method": "get_blog_entries",
-    "params": ["account", "entryId", "limit"]
-  },
-  {
-    "api": "follow_api",
-    "method": "get_blog",
-    "params": ["account", "entryId", "limit"]
-  },
-  {
-    "api": "follow_api",
-    "method": "get_account_reputations",
-    "params": ["lowerBoundName", "limit"]
-  },
-  {
-    "api": "follow_api",
-    "method": "get_reblogged_by",
-    "params": ["author", "permlink"]
-  },
-  {
-    "api": "follow_api",
-    "method": "get_blog_authors",
-    "params": ["blogAccount"]
-  },
-  {
-    "api": "network_broadcast_api",
-    "method": "broadcast_transaction",
-    "params": ["trx"]
-  },
-  {
-    "api": "network_broadcast_api",
-    "method": "broadcast_transaction_with_callback",
-    "params": ["confirmationCallback", "trx"]
-  },
-  {
-    "api": "network_broadcast_api",
-    "method": "broadcast_transaction_synchronous",
-    "params": ["trx"]
-  },
-  {
-    "api": "network_broadcast_api",
-    "method": "broadcast_block",
-    "params": ["b"]
-  },
-  {
-    "api": "network_broadcast_api",
-    "method": "set_max_block_age",
-    "params": ["maxBlockAge"]
-  },
-  {
-    "api": "market_history_api",
-    "method": "get_ticker",
-    "params": []
-  },
-  {
-    "api": "market_history_api",
-    "method": "get_volume",
-    "params": []
-  },
-  {
-    "api": "market_history_api",
-    "method": "get_order_book",
-    "method_name": "getMarketOrderBook",
-    "params": ["limit"]
-  },
-  {
-    "api": "market_history_api",
-    "method": "get_trade_history",
-    "params": ["start", "end", "limit"]
-  },
-  {
-    "api": "market_history_api",
-    "method": "get_recent_trades",
-    "params": ["limit"]
-  },
-  {
-    "api": "market_history_api",
-    "method": "get_market_history",
-    "params": ["bucket_seconds" , "start", "end"]
-  },
-  {
-    "api": "market_history_api",
-    "method": "get_market_history_buckets",
-    "params": []
-  }
+export default [
+    {
+      "api": "database_api",
+      "method": "set_subscribe_callback",
+      "params": ["callback", "clearFilter"]
+    },
+    {
+      "api": "database_api",
+      "method": "set_pending_transaction_callback",
+      "params": ["cb"]
+    },
+    {
+      "api": "database_api",
+      "method": "set_block_applied_callback",
+      "params": ["cb"]
+    },
+    {
+      "api": "database_api",
+      "method": "cancel_all_subscriptions"
+    },
+    {
+      "api": "database_api",
+      "method": "get_trending_tags",
+      "params": ["afterTag", "limit"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_tags_used_by_author",
+      "params": ["author"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_post_discussions_by_payout",
+      "params": ["query"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_comment_discussions_by_payout",
+      "params": ["query"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_discussions_by_trending",
+      "params": ["query"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_discussions_by_trending30",
+      "params": ["query"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_discussions_by_created",
+      "params": ["query"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_discussions_by_active",
+      "params": ["query"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_discussions_by_cashout",
+      "params": ["query"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_discussions_by_payout",
+      "params": ["query"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_discussions_by_votes",
+      "params": ["query"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_discussions_by_children",
+      "params": ["query"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_discussions_by_hot",
+      "params": ["query"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_discussions_by_feed",
+      "params": ["query"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_discussions_by_blog",
+      "params": ["query"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_discussions_by_comments",
+      "params": ["query"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_discussions_by_promoted",
+      "params": ["query"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_block_header",
+      "params": ["blockNum"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_block",
+      "params": ["blockNum"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_ops_in_block",
+      "params": ["blockNum", "onlyVirtual"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_state",
+      "params": ["path"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_trending_categories",
+      "params": ["after", "limit"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_best_categories",
+      "params": ["after", "limit"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_active_categories",
+      "params": ["after", "limit"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_recent_categories",
+      "params": ["after", "limit"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_config"
+    },
+    {
+      "api": "database_api",
+      "method": "get_dynamic_global_properties"
+    },
+    {
+      "api": "database_api",
+      "method": "get_chain_properties"
+    },
+    {
+      "api": "database_api",
+      "method": "get_feed_history"
+    },
+    {
+      "api": "database_api",
+      "method": "get_current_median_history_price"
+    },
+    {
+      "api": "database_api",
+      "method": "get_witness_schedule"
+    },
+    {
+      "api": "database_api",
+      "method": "get_hardfork_version"
+    },
+    {
+      "api": "database_api",
+      "method": "get_next_scheduled_hardfork"
+    },
+    {
+      "api": "account_by_key_api",
+      "method": "get_key_references",
+      "params": ["key"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_accounts",
+      "params": ["names"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_account_references",
+      "params": ["accountId"]
+    },
+    {
+      "api": "database_api",
+      "method": "lookup_account_names",
+      "params": ["accountNames"]
+    },
+    {
+      "api": "database_api",
+      "method": "lookup_accounts",
+      "params": ["lowerBoundName", "limit"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_account_count"
+    },
+    {
+      "api": "database_api",
+      "method": "get_conversion_requests",
+      "params": ["accountName"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_account_history",
+      "params": ["account", "from", "limit"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_owner_history",
+      "params": ["account"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_recovery_request",
+      "params": ["account"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_escrow",
+      "params": ["from", "escrowId"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_withdraw_routes",
+      "params": ["account", "withdrawRouteType"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_account_bandwidth",
+      "params": ["account", "bandwidthType"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_savings_withdraw_from",
+      "params": ["account"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_savings_withdraw_to",
+      "params": ["account"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_order_book",
+      "params": ["limit"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_open_orders",
+      "params": ["owner"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_liquidity_queue",
+      "params": ["startAccount", "limit"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_transaction_hex",
+      "params": ["trx"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_transaction",
+      "params": ["trxId"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_required_signatures",
+      "params": ["trx", "availableKeys"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_potential_signatures",
+      "params": ["trx"]
+    },
+    {
+      "api": "database_api",
+      "method": "verify_authority",
+      "params": ["trx"]
+    },
+    {
+      "api": "database_api",
+      "method": "verify_account_authority",
+      "params": ["nameOrId", "signers"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_active_votes",
+      "params": ["author", "permlink"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_account_votes",
+      "params": ["voter"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_content",
+      "params": ["author", "permlink"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_content_replies",
+      "params": ["author", "permlink"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_discussions_by_author_before_date",
+      "params": ["author", "startPermlink", "beforeDate", "limit"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_replies_by_last_update",
+      "params": ["startAuthor", "startPermlink", "limit"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_witnesses",
+      "params": ["witnessIds"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_witness_by_account",
+      "params": ["accountName"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_witnesses_by_vote",
+      "params": ["from", "limit"]
+    },
+    {
+      "api": "database_api",
+      "method": "lookup_witness_accounts",
+      "params": ["lowerBoundName", "limit"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_witness_count"
+    },
+    {
+      "api": "database_api",
+      "method": "get_active_witnesses"
+    },
+    {
+      "api": "database_api",
+      "method": "get_miner_queue"
+    },
+    {
+      "api": "database_api",
+      "method": "get_reward_fund",
+      "params": ["name"]
+    },
+    {
+      "api": "database_api",
+      "method": "get_vesting_delegations",
+      "params": ["account", "from", "limit"]
+    },
+    {
+      "api": "login_api",
+      "method": "login",
+      "params": ["username", "password"]
+    },
+    {
+      "api": "login_api",
+      "method": "get_api_by_name",
+      "params": ["database_api"]
+    },
+    {
+      "api": "login_api",
+      "method": "get_version"
+    },
+    {
+      "api": "follow_api",
+      "method": "get_followers",
+      "params": ["following", "startFollower", "followType", "limit"]
+    },
+    {
+      "api": "follow_api",
+      "method": "get_following",
+      "params": ["follower", "startFollowing", "followType", "limit"]
+    },
+    {
+      "api": "follow_api",
+      "method": "get_follow_count",
+      "params": ["account"]
+    },
+    {
+      "api": "follow_api",
+      "method": "get_feed_entries",
+      "params": ["account", "entryId", "limit"
+      ]
+    },
+    {
+      "api": "follow_api",
+      "method": "get_feed",
+      "params": ["account", "entryId", "limit"]
+    },
+    {
+      "api": "follow_api",
+      "method": "get_blog_entries",
+      "params": ["account", "entryId", "limit"]
+    },
+    {
+      "api": "follow_api",
+      "method": "get_blog",
+      "params": ["account", "entryId", "limit"]
+    },
+    {
+      "api": "follow_api",
+      "method": "get_account_reputations",
+      "params": ["lowerBoundName", "limit"]
+    },
+    {
+      "api": "follow_api",
+      "method": "get_reblogged_by",
+      "params": ["author", "permlink"]
+    },
+    {
+      "api": "follow_api",
+      "method": "get_blog_authors",
+      "params": ["blogAccount"]
+    },
+    {
+      "api": "network_broadcast_api",
+      "method": "broadcast_transaction",
+      "params": ["trx"]
+    },
+    {
+      "api": "network_broadcast_api",
+      "method": "broadcast_transaction_with_callback",
+      "params": ["confirmationCallback", "trx"]
+    },
+    {
+      "api": "network_broadcast_api",
+      "method": "broadcast_transaction_synchronous",
+      "params": ["trx"]
+    },
+    {
+      "api": "network_broadcast_api",
+      "method": "broadcast_block",
+      "params": ["b"]
+    },
+    {
+      "api": "network_broadcast_api",
+      "method": "set_max_block_age",
+      "params": ["maxBlockAge"]
+    },
+    {
+      "api": "market_history_api",
+      "method": "get_ticker",
+      "params": []
+    },
+    {
+      "api": "market_history_api",
+      "method": "get_volume",
+      "params": []
+    },
+    {
+      "api": "market_history_api",
+      "method": "get_order_book",
+      "method_name": "getMarketOrderBook",
+      "params": ["limit"]
+    },
+    {
+      "api": "market_history_api",
+      "method": "get_trade_history",
+      "params": ["start", "end", "limit"]
+    },
+    {
+      "api": "market_history_api",
+      "method": "get_recent_trades",
+      "params": ["limit"]
+    },
+    {
+      "api": "market_history_api",
+      "method": "get_market_history",
+      "params": ["bucket_seconds" , "start", "end"]
+    },
+    {
+      "api": "market_history_api",
+      "method": "get_market_history_buckets",
+      "params": []
+    }
 ];

--- a/src/api/transports/base.js
+++ b/src/api/transports/base.js
@@ -1,6 +1,5 @@
 import Promise from 'bluebird';
 import EventEmitter from 'events';
-import each from 'lodash/each';
 
 export default class Transport extends EventEmitter {
   constructor(options = {}) {
@@ -10,9 +9,7 @@ export default class Transport extends EventEmitter {
   }
 
   setOptions(options) {
-    each(options, (value, key) => {
-      this.options[key] = value;
-    });
+    Object.assign(this.options, options);
     this.stop();
   }
 
@@ -30,6 +27,7 @@ export default class Transport extends EventEmitter {
   send() {}
   start() {}
   stop() {}
+
 }
 
 Promise.promisifyAll(Transport.prototype);

--- a/src/api/transports/ws.js
+++ b/src/api/transports/ws.js
@@ -1,5 +1,4 @@
 import Promise from 'bluebird';
-import defaults from 'lodash/defaults';
 import isNode from 'detect-node';
 import newDebug from 'debug';
 
@@ -16,191 +15,112 @@ if (isNode) {
 
 const debug = newDebug('steem:ws');
 
-const DEFAULTS = {
-  apiIds: {
-    database_api: 0,
-    login_api: 1,
-    follow_api: 2,
-    network_broadcast_api: 4,
-  },
-  id: 0,
-};
-
 export default class WsTransport extends Transport {
   constructor(options = {}) {
-    defaults(options, DEFAULTS);
-    super(options);
+    super(Object.assign({id: 0}, options));
 
-    this.apiIds = options.apiIds;
-
+    this._requests = new Map();
     this.inFlight = 0;
-    this.currentP = Promise.fulfilled();
     this.isOpen = false;
-    this.releases = [];
-    this.requests = {};
-    this.requestsTime = {};
-
-    // A Map of api name to a promise to it's API ID refresh call
-    this.apiIdsP = {};
   }
 
   start() {
-    if (this.startP) {
-      return this.startP;
+
+    if (this.startPromise) {
+      return this.startPromise;
     }
-
-    const startP = new Promise((resolve, reject) => {
-      if (startP !== this.startP) return;
-      const url = this.options.websocket;
-      this.ws = new WebSocket(url);
-
-      const releaseOpen = this.listenTo(this.ws, 'open', () => {
-        debug('Opened WS connection with', url);
+ 
+    this.startPromise = new Promise((resolve, reject) => {
+      this.ws = new WebSocket(this.options.websocket);
+      this.ws.onerror = (err) => {
+        this.startPromise = null;
+        reject(err);        
+      };
+      this.ws.onopen = () => {
         this.isOpen = true;
-        releaseOpen();
+        this.ws.onerror = this.onError.bind(this);
+        this.ws.onmessage = this.onMessage.bind(this);
+        this.ws.onclose = this.onClose.bind(this);
         resolve();
-      });
-
-      const releaseClose = this.listenTo(this.ws, 'close', () => {
-        debug('Closed WS connection with', url);
-        this.isOpen = false;
-        delete this.ws;
-        this.stop();
-
-        if (startP.isPending()) {
-          reject(
-            new Error(
-              'The WS connection was closed before this operation was made',
-            ),
-          );
-        }
-      });
-
-      const releaseMessage = this.listenTo(this.ws, 'message', message => {
-        debug('Received message', message.data);
-        const data = JSON.parse(message.data);
-        const id = data.id;
-        const request = this.requests[id];
-        if (!request) {
-          debug('Steem.onMessage: unknown request ', id);
-        }
-        delete this.requests[id];
-        this.onMessage(data, request);
-      });
-
-      this.releases = this.releases.concat([
-        releaseOpen,
-        releaseClose,
-        releaseMessage,
-      ]);
-    });
-
-    this.startP = startP;
-    this.getApiIds();
-
-    return startP;
+      };
+    }); 
+    return this.startPromise;
   }
 
   stop() {
     debug('Stopping...');
-    if (this.ws) this.ws.close();
-    this.apiIdsP = {};
-    delete this.startP;
-    delete this.ws;
-    this.releases.forEach(release => release());
-    this.releases = [];
+
+    this.startPromise = null;
+    this.isOpen = false;
+    this._requests.clear();
+
+    if (this.ws) {
+      this.ws.onerror = this.ws.onmessage = this.ws.onclose = null;
+      this.ws.close();
+      this.ws = null;
+    }
   }
 
-  /**
-   * Refreshes API IDs, populating the `Steem::apiIdsP` map.
-   *
-   * @param {String} [requestName] If provided, only this API will be refreshed
-   * @param {Boolean} [force] If true the API will be forced to refresh, ignoring existing results
-   */
-
-  getApiIds(requestName, force) {
-    if (!force && requestName && this.apiIdsP[requestName]) {
-      return this.apiIdsP[requestName];
-    }
-
-    const apiNamesToRefresh = requestName
-      ? [requestName]
-      : Object.keys(this.apiIds);
-    apiNamesToRefresh.forEach(name => {
-      this.apiIdsP[name] = this.sendAsync('login_api', {
-        method: 'get_api_by_name',
-        params: [name],
-      }).then(result => {
-        if (result != null) {
-          this.apiIds[name] = result;
+  async send(api, data, callback) {
+    debug('Steem::send', api, data);
+    return this.start().then(() => {
+      const deferral = {};
+      new Promise((resolve, reject) => {
+        deferral.resolve = (val) => {
+          resolve(val);
+          callback(null, val);
+        };
+        deferral.reject = (val) => {
+          reject(val);
+          callback(val);
         }
       });
+
+      if (this.options.useAppbaseApi) {
+        api = 'condenser_api';
+      }
+
+      const _request = {
+        deferral,
+        startedAt: Date.now(),
+        message: {
+          id: data.id || this.id++,
+          method: 'call',
+          jsonrpc: '2.0',
+          params: [api, data.method, data.params]        
+        }
+      };
+      this.inFlight++;
+      this._requests.set(_request.message.id, _request);
+      this.ws.send(JSON.stringify(_request.message));
+      return deferral;
     });
-
-    // If `requestName` was provided, only wait for this API ID
-    if (requestName) {
-      return this.apiIdsP[requestName];
-    }
-
-    // Otherwise wait for all of them
-    return Promise.props(this.apiIdsP);
   }
 
-  send(api, data, callback) {
-    debug('Steem::send', api, data);
-    const id = data.id || this.id++;
-    const startP = this.start();
-
-    const apiIdsP = api === 'login_api' && data.method === 'get_api_by_name'
-      ? Promise.fulfilled()
-      : this.getApiIds(api);
-
-    if (api === 'login_api' && data.method === 'get_api_by_name') {
-      debug('Sending setup message');
-    } else {
-      debug('Going to wait for setup messages to resolve');
+  onError(error) {
+    for (let _request of this._requests) {
+      _request.deferral.reject(error);
     }
-
-    this.currentP = Promise.join(startP, apiIdsP)
-      .then(
-        () =>
-          new Promise((resolve, reject) => {
-            if (!this.ws) {
-              reject(
-                new Error(
-                  'The WS connection was closed while this request was pending',
-                ),
-              );
-              return;
-            }
-
-            const payload = JSON.stringify({
-              id,
-              method: 'call',
-              params: [this.apiIds[api], data.method, data.params],
-            });
-
-            debug('Sending message', payload);
-            this.requests[id] = {
-              api,
-              data,
-              resolve,
-              reject,
-              start_time: Date.now(),
-            };
-
-            // this.inFlight += 1;
-            this.ws.send(payload);
-          }),
-      )
-      .nodeify(callback);
-
-    return this.currentP;
+    this.stop();
   }
 
-  onMessage(message, request) {
-    const {api, data, resolve, reject, start_time} = request;
+  onClose() {
+    const error = new Error('Connection was closed');
+    for (let _request of this._requests) {
+      _request.deferral.reject(error);
+    }
+    this._requests.clear();
+  }
+
+  onMessage(websocketMessage) {
+    const message = JSON.parse(websocketMessage.data);
     debug('-- Steem.onMessage -->', message.id);
+    if (!this._requests.has(message.id)) {
+      throw new Error(`Panic: no request in queue for message id ${message.id}`);
+    }
+    const _request = this._requests.get(message.id);
+    this._requests.delete(message.id);
+
     const errorCause = message.error;
     if (errorCause) {
       const err = new Error(
@@ -209,21 +129,11 @@ export default class WsTransport extends Transport {
           ' (see err.payload for the full error payload)',
       );
       err.payload = message;
-      reject(err);
-      return;
+      _request.deferral.reject(err);
+    } else {
+      this.emit('track-performance', _request.message.method, Date.now() - _request.startedAt);
+      _request.deferral.resolve(message.result);
     }
 
-    if (api === 'login_api' && data.method === 'login') {
-      debug(
-        "network_broadcast_api API ID depends on the WS' session. " +
-          'Triggering a refresh...',
-      );
-      this.getApiIds('network_broadcast_api', true);
-    }
-
-    debug('Resolved', api, data, '->', message);
-    this.emit('track-performance', data.method, Date.now() - start_time);
-    delete this.requests[message.id];
-    resolve(message.result);
   }
 }

--- a/src/api/transports/ws.js
+++ b/src/api/transports/ws.js
@@ -61,7 +61,7 @@ export default class WsTransport extends Transport {
     }
   }
 
-  async send(api, data, callback) {
+  send(api, data, callback) {
     debug('Steem::send', api, data);
     return this.start().then(() => {
       const deferral = {};
@@ -126,7 +126,7 @@ export default class WsTransport extends Transport {
       const err = new Error(
         // eslint-disable-next-line prefer-template
         (errorCause.message || 'Failed to complete operation') +
-          ' (see err.payload for the full error payload)',
+          ' (see err.payload for the full error payload)'
       );
       err.payload = message;
       _request.deferral.reject(err);

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -136,4 +136,16 @@ describe('steem.api:', function () {
       });
     });
   });
+
+  describe('useApiOptions', () => {
+    it('works ok with the dev instances', async() => {
+      steem.api.setOptions({ useAppbaseApi: true, url: steem.config.get('websocketdev') });
+
+      const result = await steem.api.getContentAsync('yamadapc', 'test-1-2-3-4-5-6-7-9');
+      steem.api.setOptions({ useAppbaseApi: false, url: steem.config.get('websocket') });
+
+      result.should.have.properties(testPost);
+    });
+  });
+
 });

--- a/test/broadcast.test.js
+++ b/test/broadcast.test.js
@@ -60,7 +60,6 @@ describe('steem.broadcast:', () => {
         'test-1-2-3-4-5-6-7-9',
         -1000
       );
-
       tx.should.have.properties([
         'expiration',
         'ref_block_num',
@@ -152,17 +151,13 @@ describe('steem.broadcast:', () => {
   });
   
   describe('writeOperations', () => {
-    it('wrong', (done) => {
+    it('receives a properly formatted error response', () => {
       const wif = steem.auth.toWif('username', 'password', 'posting');
-      steem.broadcast.vote(wif, 'voter', 'author', 'permlink', 0, (err) => {
-        if(err && /tx_missing_posting_auth/.test(err.message)) {
-          should.exist(err.digest);
-          should.exist(err.transaction);
-          should.exist(err.transaction_id);
-          done();
-        } else {
-          console.log(err);
-        }
+      return steem.broadcast.voteAsync(wif, 'voter', 'author', 'permlink', 0).
+      then(() => {
+        throw new Error('writeOperation should have failed but it didn\'t');
+      }, (e) => {
+        should.exist(e.message);
       });
     });
   });

--- a/test/operations_test.js
+++ b/test/operations_test.js
@@ -35,8 +35,5 @@ function template(op) {
     assert(op.toObject({}, {use_default: true}))
     assert(op.toObject({}, {use_default: true, annotate: true}))
 
-    // sample json
-    let obj = op.toObject({}, {use_default: true, annotate: false})
-    console.log(" ", op.operation_name, "\t", JSON.stringify(obj), "\n")
 
 }


### PR DESCRIPTION
This PR adds an option to the client, `useAppbaseApi`, which tells the Websocket transport to switch to the new `condenser_api` supplied with Appbase-enabled versions of steemd.

Incidental to this work was removing the Websocket transport's reliance on an obsolete pattern for calling APIs in steemd.