### PR TITLE
Allow updateWitness to let user stop being a witness

### DIFF
--- a/src/auth/serializer/src/operations.js
+++ b/src/auth/serializer/src/operations.js
@@ -281,7 +281,8 @@ let witness_update = new Serializer(
     "witness_update", {
     owner: string,
     url: string,
-    block_signing_key: public_key,
+    block_signing_key: string,  // This can't be a public_key, because we need to be able to null it if we want to stop
+                                // being a witness.
     props: chain_properties,
     fee: asset
 }


### PR DESCRIPTION
Treat block signing key as a string, not a public key, to bypass public key checks. Fixes #267.