### PR TITLE
Update to "ws@3.3.2" to fix NSP issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lodash": "^4.16.4",
     "postinstall-build": "^5.0.1",
     "secure-random": "^1.1.1",
-    "ws": "^3.0.0"
+    "ws": "^3.3.2"
   },
   "devDependencies": {
     "babel-cli": "^6.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3364,9 +3364,9 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-3.2.0.tgz#d5d3d6b11aff71e73f808f40cc69d52bb6d4a185"
+ws@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.2.tgz#96c1d08b3fefda1d5c1e33700d3bfaa9be2d5608"
   dependencies:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"


### PR DESCRIPTION
NSP is triggering a vulnerability on current `ws` package. On this PR i'm updating `ws` package to newest version 3.3.2 where the issue is resolved. See more detail about the vulnerability found here: https://nodesecurity.io/advisories/550