### PR TITLE
Use jussi prod instead of dev instance to run useApiOptions test

### DIFF
--- a/test/api.test.js
+++ b/test/api.test.js
@@ -138,8 +138,8 @@ describe('steem.api:', function () {
   });
 
   describe('useApiOptions', () => {
-    it('works ok with the dev instances', async() => {
-      steem.api.setOptions({ useAppbaseApi: true, url: steem.config.get('dev_uri') });
+    it('works ok with the prod instances', async() => {
+      steem.api.setOptions({ useAppbaseApi: true, url: steem.config.get('uri') });
 
       const result = await steem.api.getContentAsync('yamadapc', 'test-1-2-3-4-5-6-7-9');
       steem.api.setOptions({ useAppbaseApi: false, url: steem.config.get('uri') });


### PR DESCRIPTION
I've removed the dev instance from the test and use jussi prod instead since the availability is not certain and test were failing. The test are passing now for me:
![image](https://user-images.githubusercontent.com/16245250/35066199-6772d900-fc02-11e7-9e2c-9c5e455348e3.png)

