### PR TITLE
Improvement method auth.verify

### DIFF
--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -15,17 +15,21 @@ var transaction = operations.transaction;
 var signed_transaction = operations.signed_transaction;
 
 Auth.verify = function (name, password, auths) {
-	var hasKey = false;
+	var verifyKeys = {};
 	var roles = [];
 	for (var role in auths) {
 		roles.push(role);
 	}
 	var pubKeys = this.generateKeys(name, password, roles);
 	roles.forEach(function (role) {
-		if (auths[role][0][0] === pubKeys[role]) {
-			hasKey = true;
-		}
+		var value = auths[role];
+		if (typeof value == 'object') value = value[0];
+		if (typeof value == 'object') value = value[0];
+		if (value === pubKeys[role]) verifyKeys[role] = true;
+		else verifyKeys[role] = false;
 	});
+	var verifyKeysKeys = Object.keys(verifyKeys);
+	if (verifyKeysKeys.length == 1) verifyKeys = verifyKeys[verifyKeysKeys[0]];
 	return hasKey;
 };
 


### PR DESCRIPTION
## Before a change:
* function returns only one result "true", it does not matter to pass one or four key;
* need pass object in which array in array (double array).

### Example:
```js
var username = 'epexa';
var password = 'P5...'; // master password
// object in which the key type public key (active, memo, owner, posting), and the value of the array in the array itself is the public key
var auths = {
	posting: [['STM6...']],
};
steem.auth.verify(username, password, auths);
```
retrun:
```js
true
```

## After the changes:
* if pass more than one key, function will return an object;
* in object no need pass array in array, can just string.

### Example:
```js
var username = 'epexa';
var password = 'P5...'; // master password
var auths = {
	posting: 'STM6...',
	memo: ['STM6...]',
	active: [['STM6...']],
};
steem.auth.verify(username, password, auths);
```
return:
```js
{ posting: true, memo: true, active: true }
```

**But the edits are compatible, can still pass in object array in array!**