### PR TITLE
Fix formatter.commentPermLink

### DIFF
--- a/src/formatter.js
+++ b/src/formatter.js
@@ -184,7 +184,15 @@ module.exports = steemAPI => {
         .replace(/[^a-zA-Z0-9]+/g, "")
         .toLowerCase();
       parentPermlink = parentPermlink.replace(/(-\d{8}t\d{9}z)/g, "");
-      return "re-" + parentAuthor + "-" + parentPermlink + "-" + timeStr;
+      let permLink =
+        "re-" + parentAuthor + "-" + parentPermlink + "-" + timeStr;
+      if (permLink.length > 255) {
+        // pay respect to STEEMIT_MAX_PERMLINK_LENGTH
+        permLink.substr(permLink.length - 255, permLink.length);
+      }
+      // permlinks must be lower case and not contain anything but
+      // alphanumeric characters plus dashes
+      return permLink.toLowerCase().replace(/[^a-z0-9-]+/g, "");
     },
 
     amount: function(amount, asset) {

--- a/test/comment.test.js
+++ b/test/comment.test.js
@@ -2,6 +2,7 @@ import Promise from 'bluebird';
 import should from 'should';
 import steem from '../src';
 import pkg from '../package.json';
+import assert from 'assert'
 
 const username = process.env.STEEM_USERNAME || 'guest123';
 const password = process.env.STEEM_PASSWORD;
@@ -65,5 +66,16 @@ describe('steem.broadcast:', () => {
         'signatures',
       ]);
     });
+  });
+});
+
+describe('commentPermLink:', () => {
+  it('does not return dots', () => {
+    var commentPermlink = steem.formatter.commentPermlink(
+      'foo.bar',
+      'the-first-physical-foo-bar-ready-to-be-shipped'
+    );
+    console.log(commentPermlink);
+    assert.equal(-1, commentPermlink.indexOf('.'));
   });
 });


### PR DESCRIPTION
Only return lowercase alphanumeric letters and dashes.
Fixes #330.