### PR TITLE
Add toHex convenience method

### DIFF
--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -76,6 +76,13 @@ Auth.isWif = function (privWif) {
 	return isWif;
 };
 
+Auth.toHex = function (wif) {
+	if (this.isPubkey(wif, 'STM'))
+		return PublicKey.fromString(wif).toHex();
+	else
+		return KeyPrivate.fromWif(wif).toHex();
+};
+
 Auth.toWif = function (name, password, role) {
 	var seed = name + role + password;
 	var brainKey = seed.trim().split(/[\t\n\v\f\r ]+/).join(' ');


### PR DESCRIPTION
I believe it makes sense to expose the toHex conversion methods instead of keeping them hidden in the KeyPrivate and PublicKey classes so steem-js users can easily convert their keys to hex format (for usage in other EC libraries for example)