### PR TITLE
fix handling of null key for disabling witness

### DIFF
--- a/src/auth/ecc/src/key_public.js
+++ b/src/auth/ecc/src/key_public.js
@@ -20,10 +20,20 @@ class PublicKey {
     }
 
     static fromBuffer(buffer) {
-        return new PublicKey(ecurve.Point.decodeFrom(secp256k1, buffer));
+        if (
+            buffer.toString("hex") ===
+            "000000000000000000000000000000000000000000000000000000000000000000"
+        )
+            return new PublicKey(null);
+        return new PublicKey(Point.decodeFrom(secp256k1, buffer));
     }
 
-    toBuffer(compressed = this.Q.compressed) {
+    toBuffer(compressed = this.Q ? this.Q.compressed : null) {
+        if (this.Q === null)
+            return Buffer.from(
+                "000000000000000000000000000000000000000000000000000000000000000000",
+                "hex"
+            );
         return this.Q.getEncoded(compressed);
     }
 

--- a/src/auth/ecc/src/key_public.js
+++ b/src/auth/ecc/src/key_public.js
@@ -25,7 +25,7 @@ class PublicKey {
             "000000000000000000000000000000000000000000000000000000000000000000"
         )
             return new PublicKey(null);
-        return new PublicKey(Point.decodeFrom(secp256k1, buffer));
+        return new PublicKey(ecurve.Point.decodeFrom(secp256k1, buffer));
     }
 
     toBuffer(compressed = this.Q ? this.Q.compressed : null) {


### PR DESCRIPTION
Fixes https://github.com/steemit/steem-js/issues/267

Returns a null PublicKey for setting witness disabled.

Tested: https://steemd.com/tx/7883ed11b554247abdb93ff8d348e83e9ae1c022