### PR TITLE
Netuoso 267 fix invalid sequence disable witness

### DIFF
--- a/src/auth/ecc/src/key_public.js
+++ b/src/auth/ecc/src/key_public.js
@@ -20,10 +20,20 @@ class PublicKey {
     }
 
     static fromBuffer(buffer) {
-        return new PublicKey(ecurve.Point.decodeFrom(secp256k1, buffer));
+        if (
+            buffer.toString("hex") ===
+            "000000000000000000000000000000000000000000000000000000000000000000"
+        )
+            return new PublicKey(null);
+        return new PublicKey(Point.decodeFrom(secp256k1, buffer));
     }
 
-    toBuffer(compressed = this.Q.compressed) {
+    toBuffer(compressed = this.Q ? this.Q.compressed : null) {
+        if (this.Q === null)
+            return Buffer.from(
+                "000000000000000000000000000000000000000000000000000000000000000000",
+                "hex"
+            );
         return this.Q.getEncoded(compressed);
     }
 

--- a/src/auth/ecc/src/key_public.js
+++ b/src/auth/ecc/src/key_public.js
@@ -25,7 +25,7 @@ class PublicKey {
             "000000000000000000000000000000000000000000000000000000000000000000"
         )
             return new PublicKey(null);
-        return new PublicKey(Point.decodeFrom(secp256k1, buffer));
+        return new PublicKey(ecurve.Point.decodeFrom(secp256k1, buffer));
     }
 
     toBuffer(compressed = this.Q ? this.Q.compressed : null) {

--- a/test/KeyFormats.js
+++ b/test/KeyFormats.js
@@ -70,6 +70,16 @@ var test = function(key) {
             var address = Address.fromPublic(public_key, true, 56);
             assert.equal(key.Compressed_PTS, address.toString());
         });
+        
+        it("null hex to pubkey", function() {
+            var public_key = PublicKey.fromHex(key.null_hex);
+            assert.equal(key.null_address, public_key.toPublicKeyString());
+        });
+        
+        it("null pubkey to hex", function() {
+            var public_key = PublicKey.fromString(key.null_address);
+            assert.equal(key.null_hex, public_key.toHex());
+        });
     });
 };
 
@@ -87,6 +97,9 @@ test({
     Uncompressed_BTC:	"STMLAFmEtM8as1mbmjVcj5dphLdPguXquimn",
     Compressed_BTC:	"STMANNTSEaUviJgWLzJBersPmyFZBY4jJETY",
     Uncompressed_PTS:	"STMEgj7RM6FBwSoccGaESJLC3Mi18785bM3T",
-    Compressed_PTS:	"STMD5rYtofD6D4UHJH6mo953P5wpBfMhdMEi"
+    Compressed_PTS:	"STMD5rYtofD6D4UHJH6mo953P5wpBfMhdMEi",
+    // https://github.com/steemit/steem-js/issues/267
+    null_hex: "000000000000000000000000000000000000000000000000000000000000000000",
+    null_address: "STM1111111111111111111111111111111114T1Anm"
 });
 


### PR DESCRIPTION
Replaces #390 by @netuoso:

> Fixes https://github.com/steemit/steem-js/issues/267
> 
> Returns a null PublicKey for setting witness disabled.
> 
> Tested: https://steemd.com/tx/7883ed11b554247abdb93ff8d348e83e9ae1c022