### PR TITLE
add prepare script to allow yarn/npm load from git

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "npm run build-browser && npm run build-node",
     "build-browser": "rm -rf dist && NODE_ENV=production node ./node_modules/webpack/bin/webpack.js && gzip -k -f ./dist/*.js && du -h ./dist/*",
     "build-node": "mkdir -p ./lib && cp -r ./src/* ./lib/ && babel ./src --out-dir ./lib",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "prepare": "npm run build-node"
   },
   "browser": {
     "ws": false,


### PR DESCRIPTION
By adding a `prepare` stanza to the `package.json` `scripts`, this allows a consumer to specify the dependency by git URL and have it transpile properly when `npm install` is run in the consumer.

```
{
  "name": "steem-program",
  "version": "1.0.0",
  "main": "index.js",
  "license": "MIT",
  "dependencies": {
    "@steemit/steem-js": "https://github.com/steemit/steem-js"
  }
}
```