### PR TITLE
Fix wrong usage of string template (fixes #423)

### DIFF
--- a/src/formatter.js
+++ b/src/formatter.js
@@ -72,7 +72,7 @@ module.exports = steemAPI => {
     if (!vesting_steem || !feed_price) {
       if (!gprops || !feed_price) {
         promises.push(
-          steemAPI.getStateAsync(`/@{username}`).then(data => {
+          steemAPI.getStateAsync(`/@${username}`).then(data => {
             gprops = data.props;
             feed_price = data.feed_price;
             vesting_steem = vestingSteem(account, gprops);


### PR DESCRIPTION
This causes an exception when trying to get `estimateAccountValue` for a user that is not yet cached.
Proposed fix for #423 