### PR TITLE
Switch to get_block_header for obtaining previous block id

### DIFF
--- a/src/broadcast/index.js
+++ b/src/broadcast/index.js
@@ -54,7 +54,7 @@ steemBroadcast._prepareTransaction = function steemBroadcast$_prepareTransaction
       // Set defaults on the transaction
       const chainDate = new Date(properties.time + 'Z');
       const refBlockNum = (properties.last_irreversible_block_num - 1) & 0xFFFF;
-      return steemApi.getBlockAsync(properties.last_irreversible_block_num).then((block) => {
+      return steemApi.getBlockHeaderAsync(properties.last_irreversible_block_num).then((block) => {
         const headBlockId = block.previous;
         return Object.assign({
           ref_block_num: refBlockNum,


### PR DESCRIPTION
While preparing a transaction for broadcast, steem-js obtains the previous block id by using `get_block`. Instead, it should use `get_block_header` which is more efficient for both the client and the server in terms of data transfer.

Closes #436 