### PR TITLE
Set the memo parameter in the account_update2 operation as optional as discussed in  #446

### DIFF
--- a/src/auth/serializer/src/operations.js
+++ b/src/auth/serializer/src/operations.js
@@ -612,7 +612,7 @@ let account_update2 = new Serializer(
     owner: optional(authority),
     active: optional(authority),
     posting: optional(authority),
-    memo_key: public_key,
+    memo_key: optional(public_key),
     json_metadata: string,
     posting_json_metadata: string,
     extensions: set(future_extensions)


### PR DESCRIPTION
Fixes  #446