### PR TITLE
Community - Set the memo parameter in the account_update2 operation as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steemit/steem-js",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Steem.js the JavaScript API for Steem blockchain",
   "main": "lib/index.js",
   "scripts": {

--- a/src/auth/serializer/src/operations.js
+++ b/src/auth/serializer/src/operations.js
@@ -612,7 +612,7 @@ let account_update2 = new Serializer(
     owner: optional(authority),
     active: optional(authority),
     posting: optional(authority),
-    memo_key: public_key,
+    memo_key: optional(public_key),
     json_metadata: string,
     posting_json_metadata: string,
     extensions: set(future_extensions)

--- a/test/hf20-accounts.test.js
+++ b/test/hf20-accounts.test.js
@@ -29,9 +29,7 @@ describe('steem.hf20-accounts:', () => {
       }
 
       steem.api.callAsync('condenser_api.get_version', []).then((result) => {
-        if(result['blockchain_version'] < '0.21.0') return done(); /* SKIP AS THIS WILL ONLY PASS ON A TESTNET CURRENTLY */
-        result.should.have.property('blockchain_version');
-        //result.should.have.property('blockchain_version', '0.22.0')
+        if(result['blockchain_version'] < '0.22.0') return done(); /* SKIP AS THIS WILL ONLY PASS ON A TESTNET CURRENTLY */
 
         steem.broadcast._prepareTransaction(tx).then(function(tx){
           tx = steem.auth.signTransaction(tx, [activeWif]);
@@ -48,9 +46,7 @@ describe('steem.hf20-accounts:', () => {
       this.skip(); // (!) need test account with enough RC
 
       steem.api.callAsync('condenser_api.get_version', []).then((result) => {
-        if(result['blockchain_version'] < '0.21.0') return done(); /* SKIP AS THIS WILL ONLY PASS ON A TESTNET CURRENTLY */
-        result.should.have.property('blockchain_version');
-        //result.should.have.property('blockchain_version', '0.22.0')
+        if(result['blockchain_version'] < '0.22.0') return done(); /* SKIP AS THIS WILL ONLY PASS ON A TESTNET CURRENTLY */
 
         steem.broadcast.claimAccountAsync(activeWif, username, '0.000 TESTS', []).then((result) => {
             let newAccountName = username + '-' + Math.floor(Math.random() * 10000);

--- a/test/hf21-sps.test.js
+++ b/test/hf21-sps.test.js
@@ -38,7 +38,7 @@ describe('steem.hf21-accounts:', () => {
       }
 
       steem.api.callAsync('condenser_api.get_version', []).then((result) => {
-        if(result['blockchain_version'] < '0.21.0') return done(); /* SKIP AS THIS WILL ONLY PASS ON A TESTNET CURRENTLY */
+        if(result['blockchain_version'] < '0.22.0') return done(); /* SKIP AS THIS WILL ONLY PASS ON A TESTNET CURRENTLY */
         result.should.have.property('blockchain_version');
 
         steem.broadcast._prepareTransaction(tx).then(function(tx){


### PR DESCRIPTION
From @drov0 #447:

> Set the memo parameter in the account_update2 operation as optional as discussed in  #446
> Fixes #446