### PR TITLE
Fix the condition error of useCommentPermlink

### DIFF
--- a/src/broadcast/index.js
+++ b/src/broadcast/index.js
@@ -76,7 +76,7 @@ operations.forEach((operation) => {
   const operationParams = operation.params || [];
 
   const useCommentPermlink =
-    operationParams.indexOf('parent_permlink') !== -1 &&
+    operationParams.indexOf('parent_author') !== -1 &&
     operationParams.indexOf('parent_permlink') !== -1;
 
   steemBroadcast[`${operationName}With`] =


### PR DESCRIPTION
### Description

should be an typo in the previous version:
- `useCommentPermlink` should be true when both `parent_author` and `parent_permlink` are needed. 

