### PR TITLE
Add support of rc_api.find_rc_accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ $ npm install steem --save
 
 ## RPC Servers
 https://api.steemit.com By Default<br/>
-https://node.steem.ws<br/>
-https://this.piston.rocks<br/>
 
 ## Examples
 ### Broadcast Vote
@@ -107,7 +105,7 @@ steem.api.setOptions({
 The Chain ID could change. If it does, it may not be reflected here, but will be documented on any testnet launch announcements.
 
 ## Contributions
-Patches are welcome! Contributors are listed in the package.json file. Please run the tests before opening a pull request and make sure that you are passing all of them. If you would like to contribute, but don't know what to work on, check the issues list or on Steemit Chat channel #steemjs https://steemit.chat/channel/steemjs.
+Patches are welcome! Contributors are listed in the package.json file. Please run the tests before opening a pull request and make sure that you are passing all of them. If you would like to contribute, but don't know what to work on, check the issues list.
 
 ## Issues
 When you find issues, please report them!

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -51,6 +51,7 @@ class Steem extends EventEmitter {
                 const callback = args[methodParams.length];
                 return this[`${methodName}With`](options, callback);
             };
+
             this[`${methodName}WithAsync`] = Promise.promisify(this[`${methodName}With`]);
             this[`${methodName}Async`] = Promise.promisify(this[methodName]);
         });

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -31,9 +31,15 @@ class Steem extends EventEmitter {
             const methodParams = method.params || [];
 
             this[`${methodName}With`] = (options, callback) => {
+                let params;
+                if (!method.is_object) {
+                    params = methodParams.map(param => options[param]);
+                } else {
+                    params = options;
+                }
                 return this.send(method.api, {
                     method: method.method,
-                    params: methodParams.map(param => options[param])
+                    params: params
                 }, callback);
             };
 
@@ -46,7 +52,7 @@ class Steem extends EventEmitter {
                 return this[`${methodName}With`](options, callback);
             };
 
-	          this[`${methodName}WithAsync`] = Promise.promisify(this[`${methodName}With`]);
+	        this[`${methodName}WithAsync`] = Promise.promisify(this[`${methodName}With`]);
             this[`${methodName}Async`] = Promise.promisify(this[methodName]);
         });
         this.callAsync = Promise.promisify(this.call);

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -51,8 +51,7 @@ class Steem extends EventEmitter {
                 const callback = args[methodParams.length];
                 return this[`${methodName}With`](options, callback);
             };
-
-	        this[`${methodName}WithAsync`] = Promise.promisify(this[`${methodName}With`]);
+            this[`${methodName}WithAsync`] = Promise.promisify(this[`${methodName}With`]);
             this[`${methodName}Async`] = Promise.promisify(this[methodName]);
         });
         this.callAsync = Promise.promisify(this.call);

--- a/src/api/methods.js
+++ b/src/api/methods.js
@@ -510,5 +510,11 @@ export default [
       "api": "condenser_api",
       "method": "get_nai_pool",
       "params": []
-    }
+    },
+    {
+      "api": "rc_api",
+      "method": "find_rc_accounts",
+      "params": ["accounts"],
+      "is_object": true
+    },
 ];

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -323,4 +323,17 @@ describe('steem.api:', function () {
     it('does not retry non-retriable operations');
   });
 
+  describe('getRC', () => {
+    describe('getting a RC of an account', () => {
+      it('works', async () => {
+        const result = await steem.api.findRcAccountsAsync(["justinsunsteemit"]);
+        console.debug(result);
+        result.should.have.properties("rc_accounts");
+        result["rc_accounts"][0].should.have.properties("rc_manabar");
+      });
+      it('clears listeners', async () => {
+        steem.api.listeners('message').should.have.lengthOf(0);
+      });
+    });
+  });
 });

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -327,7 +327,6 @@ describe('steem.api:', function () {
     describe('getting a RC of an account', () => {
       it('works', async () => {
         const result = await steem.api.findRcAccountsAsync(["justinsunsteemit"]);
-        console.debug(result);
         result.should.have.properties("rc_accounts");
         result["rc_accounts"][0].should.have.properties("rc_manabar");
       });


### PR DESCRIPTION
Added rc_api.find_rc_accounts. For example:

```js
async function test() {
    return await steem.api.findRcAccountsAsync(["justinsunsteemit"]);
}
```

Passing all tests `npm test`.

![image](https://github.com/steemit/steem-js/assets/1764434/4f55c1c5-f9a6-41f9-a179-e8596cf5ba10)

![image](https://github.com/steemit/steem-js/assets/1764434/f9029ed3-89fa-47ab-8f08-3da901d501f9)

