### PR TITLE
Add steem.api.getExpiringVestingDelegationsAsync

### DIFF
--- a/src/api/methods.js
+++ b/src/api/methods.js
@@ -517,4 +517,9 @@ export default [
       "params": ["accounts"],
       "is_object": true
     },
+    {
+      "api": "condenser_api",
+      "method": "get_expiring_vesting_delegations",
+      "params": ["account", "start", "limit"],
+    }
 ];

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -335,4 +335,26 @@ describe('steem.api:', function () {
       });
     });
   });
+
+  describe('getExpiringDelegations', () => {
+    describe('getting expired delegation of an account', () => {
+      it('works', async () => {
+        function now() {
+          const date = new Date();
+          const year = date.getFullYear();
+          const month = String(date.getMonth() + 1).padStart(2, '0'); // Adding 1 because getMonth() returns 0-11
+          const day = String(date.getDate()).padStart(2, '0');
+          const hours = String(date.getHours()).padStart(2, '0');
+          const minutes = String(date.getMinutes()).padStart(2, '0');
+          const seconds = String(date.getSeconds()).padStart(2, '0');
+          return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
+        }
+        const result = await steem.api.getExpiringVestingDelegationsAsync("justyy", now(), 100);
+        result.should.have.properties("length");
+      });
+      it('clears listeners', async () => {
+        steem.api.listeners('message').should.have.lengthOf(0);
+      });
+    });
+  })
 });


### PR DESCRIPTION
This PR adds `get_expiring_vesting_delegations` to `steem.api` 

```js
steem.api.send(
    "condenser_api",
    {
        method: "get_expiring_vesting_delegations",
        params: [ 'justyy', '2024-08-12T20:28:30', 100 ]
    },
    function (err, res) {
        console.log(err, res);
    }
);
```

![image](https://github.com/user-attachments/assets/eebddbb1-ffa1-4ccb-b881-341c32cbe8cb)

