### PR TITLE
Add steem.api.findChangeRecoveryAccountRequests

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1156,6 +1156,30 @@ Return Example:
    { account: 'username-taken', reputation: 0 } ]
 ```
 - - - - - - - - - - - - - - - - - -
+## Recovery Account Change Requests
+Get the change requests of recovery account for multiple accounts.
+
+```js
+steem.api.findChangeRecoveryAccountRequests(['justyy222', 'ety001', 'justyy'], function(err, data) {
+	console.log(err, data);
+});
+```
+
+Return Example:
+
+```js
+{"requests":
+  [
+    {
+      "id":2238,
+      "account_to_recover":"justyy222",
+      "recovery_account":"happyukgo",
+      "effective_on":"2024-09-24T06:15:33"
+    }
+  ]
+}
+```
+- - - - - - - - - - - - - - - - - -
 ## Market
 - - - - - - - - - - - - - - - - - -
 ### Get Order Book

--- a/src/api/methods.js
+++ b/src/api/methods.js
@@ -521,5 +521,11 @@ export default [
       "api": "condenser_api",
       "method": "get_expiring_vesting_delegations",
       "params": ["account", "start", "limit"],
+    },
+    {
+      "api": "database_api",
+      "method": "find_change_recovery_account_requests",
+      "params": ["account"],
+      "is_object": true
     }
 ];

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -346,5 +346,18 @@ describe('steem.api:', function () {
         steem.api.listeners('message').should.have.lengthOf(0);
       });
     });
-  })
+  });
+
+  describe('Account Recovery', () => {
+    describe('findChangeRecoveryAccountRequests', () => {
+      it('works', async () => {
+        const result = await steem.api.findChangeRecoveryAccountRequestsAsync(["justyy", "ety001"]);
+        result.should.have.properties("requests");
+        result.requests.should.have.properties("length");
+      });
+      it('clears listeners', async () => {
+        steem.api.listeners('message').should.have.lengthOf(0);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Get the change requests of recovery account for multiple accounts.

```js
steem.api.findChangeRecoveryAccountRequests(['justyy222', 'ety001', 'justyy'], function(err, data) {
	console.log(err, data);
});
```

Return Example:

```js
{"requests":
  [
    {
      "id":2238,
      "account_to_recover":"justyy222",
      "recovery_account":"happyukgo",
      "effective_on":"2024-09-24T06:15:33"
    }
  ]
}
```

![image](https://github.com/user-attachments/assets/115fd7cd-cfe9-4ffa-99bf-384ce3e4b645)
