### PR TITLE
Adds changes to fix witness_set_properties

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1894,6 +1894,28 @@ steem.broadcast.feedPublish(wif, publisher, exchangeRate, function(err, result) 
 });
 ```
 - - - - - - - - - - - - - - - - - -
+### Build Witness Update Properties
+```
+const owner = 'starlord28'
+const props = {
+  "key": "Public Signing Key", // MANDATORY
+  "new_signing_key": "Public Signing Key", // optional
+  "account_creation_fee": "3.000 STEEM", // optional
+  "account_subsidy_budget": 0, // optional
+  "account_subsidy_decay": 0, // optional
+  "maximum_block_size": 65536, // optional
+  "sbd_interest_rate": "0.000 STEEM", // optional
+  "sbd_exchange_rate": {"base": "0.237 SBD", "quote": "1.000 STEEM"}, // optional
+  "url": "https://steemcryptic.me", // optional
+}
+
+const witnessOps = steem.utils.buildWitnessSetProperties(props);
+
+steem.broadcast.witnessSetProperties('Private Signing Key', owner, witnessOps, [], function(err, result) {
+  console.log(err, result);
+});
+```
+- - - - - - - - - - - - - - - - - -
 ### Fill Convert Request
 ```js
 steem.broadcast.fillConvertRequest(wif, owner, requestid, amountIn, amountOut, function(err, result) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steemit/steem-js",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "description": "Steem.js the JavaScript API for Steem blockchain",
   "main": "lib/index.js",
   "scripts": {

--- a/src/auth/serializer/src/operations.js
+++ b/src/auth/serializer/src/operations.js
@@ -661,7 +661,7 @@ let account_create_with_delegation = new Serializer(
 let witness_set_properties = new Serializer(
     "witness_set_properties", {
     owner: string,
-    props: string,
+    props: map(string, bytes()),
     extensions: set(future_extensions)
 }
 );


### PR DESCRIPTION
The witness_set_properties operation requires each value in props to be serialized individually before serializing props as a FlatMap(StringSerializer, BinarySerializer). While the condenser API documentation shows props as an object, which simplifies working with the operation, it must be converted into an array by the transaction serializer/broadcaster before sending it to the node. If this conversion is not done, the transaction will not be accepted.
This can now be used to also broadcast the witness pricefeed using the witness private key itself.
![image](https://github.com/user-attachments/assets/66f2e453-41a8-41c2-9cf2-f1c2d3f63b99)
