### PR TITLE
fix(security): limit recovery debug to development (#11)

### DIFF
--- a/src/auth/ecc/src/ecdsa.ts
+++ b/src/auth/ecc/src/ecdsa.ts
@@ -250,19 +250,22 @@ export function calcPubKeyRecoveryParam(curve: ECInstance, e: BN, signature: ECS
             }
         } catch (error) {
             // try next value
-            console.debug(`Recovery attempt ${i} failed:`, (error as Error).message);
+            if (process.env.NODE_ENV === 'development') {
+                console.debug(`Recovery attempt ${i} failed:`, (error as Error).message);
+            }
         }
     }
 
-    // Additional debugging
-    console.debug('All recovery attempts failed. Signature:', {
-        r: signature.r.toString(16),
-        s: signature.s.toString(16)
-    });
-    console.debug('Expected public key:', {
-        x: Q.getX().toString(16),
-        y: Q.getY().toString(16)
-    });
+    if (process.env.NODE_ENV === 'development') {
+        console.debug('All recovery attempts failed. Signature:', {
+            r: signature.r.toString(16),
+            s: signature.s.toString(16)
+        });
+        console.debug('Expected public key:', {
+            x: Q.getX().toString(16),
+            y: Q.getY().toString(16)
+        });
+    }
 
     throw new Error('Unable to find valid recovery factor');
 } 


### PR DESCRIPTION
Security audit fix No. 11: log r/s and pubkey only when NODE_ENV=development. Ref: SECURITY_AUDIT_REPORT-glm.md