### PR TITLE
fix(api): route legacy RPC methods through condenser_api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.16] - 2026-05-21
+
+### Fixed
+
+- Route 51 legacy read RPC helpers through **`condenser_api`** instead of **`database_api`**, matching current [steem](https://github.com/steemit/steem) full nodes (fixes `Could not find method` errors for `get_accounts`, `get_content`, discussions, etc.).
+- Keep 12 helpers on **`database_api`** where the node still exposes them (`get_config`, `get_dynamic_global_properties`, `verify_authority`, `find_change_recovery_account_requests`, …).
+
+### Removed
+
+- Drop 30 `steem.api.*` helpers that are not implemented on current Steem nodes (WebSocket subscriptions, category listings, `getDiscussionsByPayout`, proposed-transaction getters, escrow-by-side helpers, account bandwidth/notifications, `getLiquidityQueue`, `getMinerQueue`, …). See [API routing](./docs/README.md#api-routing).
+
+### Changed
+
+- Documentation and source comments updated for condenser vs database API routing ([docs/README.md#api-routing](./docs/README.md#api-routing), [refactoring notes](./docs/refactoring-2025.md#11-api-rpc-routing-v1016)).
+
+## [1.0.15] - 2026-05-21
+
+### Changed
+
+- Bump package version to 1.0.15.
+
+### Added
+
+- `clean` script; run `clean` before `build` in the build pipeline.
+
+## [1.0.14] - (prior release)
+
+Previous release on npm before the routing fix branch. See git history and [refactoring-2025.md](./docs/refactoring-2025.md) for the 2025 modernization work.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A modern JavaScript/TypeScript library for interacting with the Steem blockchain
 
 **[👉 Complete API Documentation](./docs/README.md)** - Comprehensive guide with all methods, examples, and usage patterns
 
+**[API routing (condenser_api vs database_api)](./docs/README.md#api-routing)** - How RPC namespaces map to current Steem nodes (v1.0.16+)
+
 **[🔧 Refactoring Details](./docs/refactoring-2025.md)** - Technical details about the 2025 modernization
 
 ## 🚀 Quick Start
@@ -65,6 +67,7 @@ await steem.broadcast.voteAsync(postingWif, 'voter', 'author', 'permlink', 10000
 
 ## ✨ Key Features
 
+- **🔗 Correct RPC routing** - Legacy read APIs use `condenser_api`; chain/validation APIs use `database_api` (v1.0.16+, aligned with [steem](https://github.com/steemit/steem))
 - **🔒 Type Safety** - Full TypeScript support with complete type definitions
 - **⚡ Modern** - ES modules, async/await, modern cryptography libraries
 - **🌐 Universal** - Works in Node.js, browsers, and bundlers
@@ -102,7 +105,7 @@ This is a complete modernization of the original steem-js library:
 
 ```
 src/
-├── api/          # Blockchain API client (HTTP)
+├── api/          # Blockchain API client (HTTP; methods.ts → condenser_api / database_api / …)
 ├── auth/         # Authentication and key management
 ├── broadcast/    # Transaction broadcasting
 ├── crypto/       # Cryptographic utilities

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A modern JavaScript/TypeScript library for interacting with the Steem blockchain
 
 **[API routing (condenser_api vs database_api)](./docs/README.md#api-routing)** - How RPC namespaces map to current Steem nodes (v1.0.16+)
 
+**[📋 Changelog](./CHANGELOG.md)** - Version history and breaking changes
+
 **[🔧 Refactoring Details](./docs/refactoring-2025.md)** - Technical details about the 2025 modernization
 
 ## 🚀 Quick Start

--- a/docs/README.md
+++ b/docs/README.md
@@ -2233,6 +2233,7 @@ MIT
 
 - **[SignedCall Examples](./signedCall-examples.md)** - Comprehensive guide for authenticated API calls
 - **[Signature Verification Examples](./signature-verification-examples.md)** - Complete guide for verifying signatures
+- **[Changelog](../CHANGELOG.md)** - Release notes (v1.0.16 routing changes)
 - **[Refactoring History](./refactoring-2025.md)** - Technical details about the 2025 modernization
 
 ## Contributing

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 Steem.js is a JavaScript/TypeScript library for interacting with the Steem blockchain. This documentation provides complete API reference and usage examples.
 
+> **v1.0.16+:** Most `steem.api` read helpers call **`condenser_api`** on the node; see [API routing](#api-routing) for namespaces, removed methods, and modern `database_api` `list_*` / `find_*` usage.
+
 ## Table of Contents
 
 - [Installation](#installation)
@@ -10,8 +12,8 @@ Steem.js is a JavaScript/TypeScript library for interacting with the Steem block
 - [JSON-RPC](#json-rpc)
     - [Signed RPC Calls](#signed-rpc-calls)
     - [Signature Verification](#signature-verification)
-- [Database API](#database-api)
-    - [Subscriptions](#subscriptions)
+- [API routing](#api-routing)
+- [Read API methods](#read-api-methods)
     - [Tags](#tags)
     - [Blocks and Transactions](#blocks-and-transactions)
     - [Global Properties](#global-properties)
@@ -380,7 +382,7 @@ steem.api.signedCall(method, params, account, privateKey, callback);
 
 | Parameter | Data Type | Description |
 |---------|--------|-----------|
-| method | string | The RPC method name to call |
+| method | string | Full RPC method name (e.g. `condenser_api.get_account_history`) |
 | params | array | Parameters for the RPC method |
 | account | string | The account name making the request |
 | privateKey | string | Private key (WIF format) for signing |
@@ -496,41 +498,46 @@ const isValid = signatureVerification.verifyMessageSignature(message, signature,
 
 ---
 
-## Database API
+## API routing
 
-### Subscriptions
+Steem nodes expose multiple JSON-RPC plugin namespaces. steem-js maps each `steem.api.*` helper to a namespace in `src/api/methods.ts`.
 
-#### Set Subscribe Callback
+### How requests are sent
 
-```javascript
-steem.api.setSubscribeCallback(callback, clearFilter, function(err, result) {
-  console.log(err, result);
-});
-```
+| Style | Example | Wire format (HTTP) |
+|-------|---------|-------------------|
+| Generated helper | `steem.api.getAccountsAsync(['ned'])` | JSON-RPC `call` with `['condenser_api', 'get_accounts', [['ned']]]` |
+| Explicit namespace | `steem.api.call('condenser_api.get_accounts', [['ned']])` | JSON-RPC method `condenser_api.get_accounts` |
 
-#### Set Pending Transaction Callback
+As of **v1.0.16**, legacy read helpers (`get_accounts`, `get_content`, discussions, witnesses, …) use **`condenser_api`**, matching current [steem](https://github.com/steemit/steem) full nodes. Methods that remain on the modern **`database_api`** plugin include `get_config`, `get_dynamic_global_properties`, `get_transaction_hex`, `get_required_signatures`, `get_potential_signatures`, `verify_authority`, `verify_account_authority`, `get_order_book`, `get_witness_schedule`, `get_active_witnesses`, `get_feed_history`, and `find_change_recovery_account_requests`.
 
-```javascript
-steem.api.setPendingTransactionCallback(cb, function(err, result) {
-  console.log(err, result);
-});
-```
+### Modern `database_api` (`list_*` / `find_*`)
 
-#### Set Block Applied Callback
+The node's native `database_api` plugin uses different method names and object-shaped parameters (e.g. `database_api.find_accounts` with `{ accounts: ['user'] }`). Those are **not** exposed as camelCase helpers; call them with:
 
 ```javascript
-steem.api.setBlockAppliedCallback(cb, function(err, result) {
-  console.log(err, result);
-});
+await steem.api.callAsync('database_api.find_accounts', [{ accounts: ['initminer'] }]);
 ```
 
-#### Cancel All Subscriptions
+### Removed helpers (v1.0.16)
 
-```javascript
-steem.api.cancelAllSubscriptions(function(err, result) {
-  console.log(err, result);
-});
-```
+These `steem.api.*` methods were removed from the library because they are not implemented on current Steem nodes:
+
+- WebSocket subscriptions: `setSubscribeCallback`, `setPendingTransactionCallback`, `setBlockAppliedCallback`, `cancelAllSubscriptions`
+- Categories: `getTrendingCategories`, `getBestCategories`, `getActiveCategories`, `getRecentCategories`
+- Discussions: `getDiscussionsByTrending30`, `getDiscussionsByPayout`
+- Account: `getAccountNotifications`, `getAccountReputation`, `getAccountBandwidth`, `getAccountBandwidthByType`, `getAccountBandwidthByTypeAndTime`
+- Market / mining: `getLiquidityQueue`, `getMinerQueue`
+- Escrow: `getEscrowByFrom`, `getEscrowByTo`, `getEscrowByAgent`
+- Proposed transactions: `getProposedTransactions`, `getProposedTransaction`, and related `getProposedTransactionApprovals*` variants
+
+Use `getEscrow` / `condenser_api` or `database_api.list_escrows` / `find_escrows` where applicable.
+
+---
+
+## Read API methods
+
+The sections below document `steem.api` helpers for reading chain state. Unless noted, calls are routed to **`condenser_api`** on the node.
 
 ### Tags
 
@@ -689,9 +696,6 @@ steem.api.getDiscussionsByActiveAsync(query);
 // By cashout time
 steem.api.getDiscussionsByCashoutAsync(query);
 
-// By payout amount
-steem.api.getDiscussionsByPayoutAsync(query);
-
 // By votes
 steem.api.getDiscussionsByVotesAsync(query);
 
@@ -796,6 +800,8 @@ steem.api.getStateAsync("/trending/collorchallenge");
 ```
 
 ### Global Properties
+
+`getConfig`, `getDynamicGlobalProperties`, `getFeedHistory`, and `getWitnessSchedule` use **`database_api`** on the node. `getChainProperties`, `getHardforkVersion`, and `getNextScheduledHardfork` use **`condenser_api`**.
 
 #### Get Config
 
@@ -1139,47 +1145,6 @@ steem.api.getRecoveryRequestAsync(account).then(function(result) {
 });
 ```
 
-#### Get Account Bandwidth
-
-Get the bandwidth of the `account`. The bandwidth is the limit of data that can be uploaded to the blockchain. To have bigger bandwidth - power up your Steem.
-
-```javascript
-steem.api.getAccountBandwidthAsync(account, bandwidthType).then(function(data) {
-  console.log(data);
-});
-```
-
-**Parameter Description:**
-
-| Parameter | Data Type | Description |
-|---------|--------|-----------|
-| account | string | A Steem username |
-| bandwidthType | number | This is a value from an enumeration of predefined values. '1' is for the "Forum" bandwidth, and '2' is for "Market" bandwidth |
-
-**Call Example:**
-
-```javascript
-const forumBandwidthType = 1;
-const marketBandwidthType = 2;
-
-steem.api.getAccountBandwidthAsync("username", forumBandwidthType).then(function(data) {
-  console.log(data);
-});
-```
-
-**Return Example:**
-
-```javascript
-{
-  id: 23638,
-  account: 'username',
-  type: 'forum',
-  average_bandwidth: 260815714,
-  lifetime_bandwidth: '125742000000',
-  last_bandwidth_update: '2018-02-07T22:30:42'
-}
-```
-
 #### Get Account Reputations
 
 Gets the reputation points of `limit` accounts with names most similar to `lowerBoundName`.
@@ -1242,13 +1207,7 @@ steem.api.getOpenOrdersAsync(owner).then(function(result) {
 });
 ```
 
-#### Get Liquidity Queue
-
-```javascript
-steem.api.getLiquidityQueueAsync(startAccount, limit).then(function(result) {
-  console.log(result);
-});
-```
+`getOrderBook` uses **`database_api`** on the node; `getMarketOrderBook` uses **`market_history_api`**.
 
 #### Get Market History Buckets
 
@@ -1294,6 +1253,8 @@ steem.api.getPotentialSignaturesAsync(trx).then(function(result) {
 
 #### Verify Authority
 
+Uses **`database_api`** on the node.
+
 ```javascript
 steem.api.verifyAuthorityAsync(trx).then(function(result) {
   console.log(result);
@@ -1301,6 +1262,8 @@ steem.api.verifyAuthorityAsync(trx).then(function(result) {
 ```
 
 #### Verify Account Authority
+
+Uses **`database_api`** on the node.
 
 ```javascript
 steem.api.verifyAccountAuthorityAsync(nameOrId, signers).then(function(result) {
@@ -1480,14 +1443,6 @@ steem.api.getWitnessScheduleAsync().then(function(data) {
   max_runner_witnesses: 1,
   hardfork_required_witnesses: 17
 }
-```
-
-#### Get Miner Queue
-
-```javascript
-steem.api.getMinerQueueAsync().then(function(result) {
-  console.log(result);
-});
 ```
 
 ---
@@ -2286,4 +2241,4 @@ Contributions are welcome! Please check the project's GitHub repository for more
 
 ---
 
-*This documentation is based on Steem.js v1.0.4. For updates, please refer to the latest version documentation.*
+*Documentation reflects Steem.js v1.0.16 (API routing aligned with steemit/steem condenser_api / database_api plugins).*

--- a/docs/refactoring-2025.md
+++ b/docs/refactoring-2025.md
@@ -370,3 +370,21 @@ returnType: Promise<any>
 3. **Modern Standard**: Aligns with ethers.js and modern SDKs
 4. **Simpler Code**: No external Promise library needed
 5. **Better Performance**: Native Promise is optimized by JavaScript engines
+
+## 11. API RPC routing (v1.0.16)
+
+### 11.1 Problem
+
+`src/api/methods.ts` historically registered most helpers under `database_api`. Modern [steem](https://github.com/steemit/steem) nodes implement legacy read methods on the **`condenser_api`** plugin and expose a separate **`database_api`** with `list_*` / `find_*` methods. Calling `get_accounts` via `database_api` fails at runtime.
+
+### 11.2 Changes
+
+- **51 methods** moved from `api: 'database_api'` to `api: 'condenser_api'` (e.g. `get_accounts`, `get_content`, discussions).
+- **12 methods** remain on `database_api` (e.g. `get_config`, `verify_authority`, `find_change_recovery_account_requests`).
+- **30 methods** removed from the registry (subscriptions, categories, proposed-transaction getters, etc.)—not present on current nodes.
+
+### 11.3 Usage notes
+
+- High-level helpers: `steem.api.getAccountsAsync()` (unchanged API surface).
+- New-style node APIs: `steem.api.callAsync('database_api.find_accounts', [{ accounts: ['user'] }])`.
+- See [API routing](./README.md#api-routing) in the main documentation.

--- a/docs/signedCall-examples.md
+++ b/docs/signedCall-examples.md
@@ -6,6 +6,8 @@ This document provides comprehensive examples for using `signedCall` in Steem.js
 
 `signedCall` is used for making authenticated JSON-RPC calls to the Steem blockchain. It cryptographically signs requests to prove account ownership and access private or restricted data.
 
+Pass the full RPC method name (e.g. `condenser_api.get_account_history`). Legacy read methods use the **`condenser_api`** namespace on current nodes; see [API routing](./README.md#api-routing) in the main docs.
+
 ## Basic Setup
 
 ```javascript
@@ -282,6 +284,7 @@ class SecureSignedClient {
 
   async secureCall(method, params) {
     // Additional security checks
+    // Prefer condenser_api.* for legacy reads; database_api.* for config/validation and list/find APIs.
     if (!method.startsWith('condenser_api.') && !method.startsWith('database_api.')) {
       throw new Error('Only condenser_api and database_api methods are allowed');
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steemit/steem-js",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Steem blockchain JavaScript/TypeScript library",
   "type": "module",
   "main": "dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steemit/steem-js",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Steem blockchain JavaScript/TypeScript library",
   "type": "module",
   "main": "dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "unpkg": "dist/index.umd.js",
   "jsdelivr": "dist/index.umd.js",
   "scripts": {
-    "build": "rollup -c",
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
+    "build": "pnpm run clean && rollup -c",
     "dev": "rollup -c -w",
     "test": "vitest run",
     "test:watch": "vitest watch",

--- a/src/api/TYPES.md
+++ b/src/api/TYPES.md
@@ -4,6 +4,10 @@
 
 This document describes the type definitions for the `Api` class's dynamically generated methods.
 
+## RPC routing
+
+Helpers such as `getAccounts()` are defined in `src/api/methods.ts`. Each entry sets the Steem plugin namespace (`condenser_api`, `database_api`, …) used by `Api.send()`. As of v1.0.16, most legacy read methods route through `condenser_api`; only chain/validation methods remain on `database_api`. New-style node APIs (`list_accounts`, `find_accounts`, …) are not generated as camelCase helpers—use `api.call('database_api.find_accounts', [args])` instead.
+
 ## Problem
 
 The `Api` class dynamically generates methods at runtime based on the `methods.ts` configuration. TypeScript cannot automatically infer these methods, causing type errors when trying to use them (e.g., `api.getAccounts()`).

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -69,6 +69,7 @@ export class Api extends EventEmitter {
     this._setLogger(options);
     this.options = options;
 
+    // Register steem.api.* from src/api/methods.ts; each call uses method.api as the RPC namespace.
     methods.forEach(method => {
       const methodName = method.method_name || camelCase(method.method);
       const methodParams = method.params || [];
@@ -207,6 +208,11 @@ export class Api extends EventEmitter {
     return this.transport.stop();
   }
 
+  /**
+   * Send a JSON-RPC request via the active transport.
+   * HTTP uses the legacy `call` wrapper: params are [apiNamespace, methodName, args].
+   * @param api Plugin namespace (e.g. condenser_api, database_api)
+   */
   send(api: string, data: unknown, callback: unknown) {
     let cb = callback as (err: Error | null, result?: unknown) => void;
     if (this.__logger) {
@@ -775,7 +781,8 @@ export class Api extends EventEmitter {
   }
 
   /**
-   * Verify transaction authority.
+   * Verify transaction authority (database_api.verify_authority on the node).
+   * Prefer verifyAuthorityAsync; dynamically generated helpers also exist from methods.ts.
    * @param trx Transaction object to verify
    * @param callback Optional callback function
    * @returns Promise with verification result if no callback provided
@@ -810,7 +817,7 @@ export class Api extends EventEmitter {
   }
 
   /**
-   * Verify account authority.
+   * Verify account authority (database_api.verify_account_authority on the node).
    * @param nameOrId Account name or ID
    * @param signers Array of signer public keys
    * @param callback Optional callback function
@@ -863,8 +870,8 @@ export function signTransaction(trx: unknown, keys: string[]) {
   return api.signTransaction(trx, keys);
 }
 
+/** @deprecated Use `api.verifyAuthority` / `verifyAuthorityAsync` on the Api instance instead. */
 export function verifyAuthority(..._args: unknown[]) {
-  // Implementation would go here
   return false;
 }
 

--- a/src/api/methods.ts
+++ b/src/api/methods.ts
@@ -1,3 +1,18 @@
+/**
+ * Registry of JSON-RPC methods exposed as steem.api.* helpers.
+ *
+ * Each entry's `api` field is the Steem node plugin namespace sent on the wire
+ * (legacy HTTP transport uses JSON-RPC `call` with [api, method, params]).
+ *
+ * Routing policy (aligned with steemit/steem):
+ * - condenser_api: legacy read helpers (get_accounts, get_content, discussions, …)
+ * - database_api: chain/validation APIs still on the modern database_api plugin
+ * - follow_api, network_broadcast_api, market_history_api, etc.: other plugins
+ *
+ * Methods removed from this list in v1.0.16 are no longer served by current nodes
+ * (e.g. websocket subscriptions, category listings, proposed-transaction getters).
+ */
+
 interface ApiMethod {
   api: string;
   method: string;

--- a/src/api/methods.ts
+++ b/src/api/methods.ts
@@ -7,620 +7,567 @@ interface ApiMethod {
 }
 
 const methods: ApiMethod[] = [
+
   {
-    api: 'database_api',
-    method: 'set_subscribe_callback',
-    params: ['callback', 'clearFilter']
-  },
-  {
-    api: 'database_api',
-    method: 'set_pending_transaction_callback',
-    params: ['cb']
-  },
-  {
-    api: 'database_api',
-    method: 'set_block_applied_callback',
-    params: ['cb']
-  },
-  {
-    api: 'database_api',
-    method: 'cancel_all_subscriptions'
-  },
-  {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_trending_tags',
     params: ['afterTag', 'limit']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_tags_used_by_author',
     params: ['author']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_post_discussions_by_payout',
     params: ['query']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_comment_discussions_by_payout',
     params: ['query']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_discussions_by_trending',
     params: ['query']
   },
+
   {
-    api: 'database_api',
-    method: 'get_discussions_by_trending30',
-    params: ['query']
-  },
-  {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_discussions_by_created',
     params: ['query']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_discussions_by_active',
     params: ['query']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_discussions_by_cashout',
     params: ['query']
   },
+
   {
-    api: 'database_api',
-    method: 'get_discussions_by_payout',
-    params: ['query']
-  },
-  {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_discussions_by_votes',
     params: ['query']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_discussions_by_children',
     params: ['query']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_discussions_by_hot',
     params: ['query']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_discussions_by_feed',
     params: ['query']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_discussions_by_blog',
     params: ['query']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_discussions_by_comments',
     params: ['query']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_discussions_by_promoted',
     params: ['query']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_block_header',
     params: ['blockNum']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_block',
     params: ['blockNum']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_ops_in_block',
     params: ['blockNum', 'onlyVirtual']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_state',
     params: ['path']
   },
-  {
-    api: 'database_api',
-    method: 'get_trending_categories',
-    params: ['after', 'limit']
-  },
-  {
-    api: 'database_api',
-    method: 'get_best_categories',
-    params: ['after', 'limit']
-  },
-  {
-    api: 'database_api',
-    method: 'get_active_categories',
-    params: ['after', 'limit']
-  },
-  {
-    api: 'database_api',
-    method: 'get_recent_categories',
-    params: ['after', 'limit']
-  },
+
   {
     api: 'database_api',
     method: 'get_config'
   },
+
   {
     api: 'database_api',
     method: 'get_dynamic_global_properties'
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_chain_properties'
   },
+
   {
     api: 'database_api',
     method: 'get_feed_history'
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_current_median_history_price'
   },
+
   {
     api: 'database_api',
     method: 'get_witness_schedule'
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_hardfork_version'
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_next_scheduled_hardfork'
   },
+
   {
     api: 'account_by_key_api',
     method: 'get_key_references',
     params: ['key']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_accounts',
     params: ['names']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_account_references',
     params: ['accountId']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'lookup_account_names',
     params: ['accountNames']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'lookup_accounts',
     params: ['lowerBoundName', 'limit']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_account_count'
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_conversion_requests',
     params: ['accountName']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_account_history',
     params: ['account', 'from', 'limit']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_owner_history',
     params: ['account']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_recovery_request',
     params: ['account']
   },
+
   {
     api: 'follow_api',
     method: 'get_followers',
     params: ['following', 'startFollower', 'followType', 'limit']
   },
+
   {
     api: 'follow_api',
     method: 'get_following',
     params: ['follower', 'startFollowing', 'followType', 'limit']
   },
+
   {
     api: 'follow_api',
     method: 'get_follow_count',
     params: ['account']
   },
+
   {
     api: 'follow_api',
     method: 'get_feed_entries',
     params: ['account', 'entryId', 'limit']
   },
+
   {
     api: 'follow_api',
     method: 'get_feed',
     params: ['account', 'entryId', 'limit']
   },
+
   {
     api: 'follow_api',
     method: 'get_blog_entries',
     params: ['account', 'entryId', 'limit']
   },
+
   {
     api: 'follow_api',
     method: 'get_blog',
     params: ['account', 'entryId', 'limit']
   },
+
   {
     api: 'follow_api',
     method: 'get_account_reputations',
     params: ['lowerBoundName', 'limit']
   },
+
   {
     api: 'follow_api',
     method: 'get_reblogged_by',
     params: ['author', 'permlink']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_content',
     params: ['author', 'permlink']
   },
+
   {
-    api: 'database_api',
-    method: 'get_account_notifications',
-    params: ['account', 'from', 'limit']
-  },
-  {
-    api: 'database_api',
-    method: 'get_account_reputation',
-    params: ['account']
-  },
-  {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_escrow',
     params: ['from', 'escrowId']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_withdraw_routes',
     params: ['account', 'withdrawRouteType']
   },
+
   {
-    api: 'database_api',
-    method: 'get_account_bandwidth',
-    params: ['account', 'bandwidthType']
-  },
-  {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_savings_withdraw_from',
     params: ['account']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_savings_withdraw_to',
     params: ['account']
   },
+
   {
     api: 'database_api',
     method: 'get_order_book',
     params: ['limit']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_open_orders',
     params: ['owner']
   },
-  {
-    api: 'database_api',
-    method: 'get_liquidity_queue',
-    params: ['startAccount', 'limit']
-  },
+
   {
     api: 'database_api',
     method: 'get_transaction_hex',
     params: ['trx']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_transaction',
     params: ['trxId']
   },
+
   {
     api: 'database_api',
     method: 'get_required_signatures',
     params: ['trx', 'availableKeys']
   },
+
   {
     api: 'database_api',
     method: 'get_potential_signatures',
     params: ['trx']
   },
+
   {
     api: 'database_api',
     method: 'verify_authority',
     params: ['trx']
   },
+
   {
     api: 'database_api',
     method: 'verify_account_authority',
     params: ['nameOrId', 'signers']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_active_votes',
     params: ['author', 'permlink']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_account_votes',
     params: ['voter']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_content_replies',
     params: ['author', 'permlink']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_discussions_by_author_before_date',
     params: ['author', 'startPermlink', 'beforeDate', 'limit']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_replies_by_last_update',
     params: ['startAuthor', 'startPermlink', 'limit']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_witnesses',
     params: ['witnessIds']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_witness_by_account',
     params: ['accountName']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_witnesses_by_vote',
     params: ['from', 'limit']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'lookup_witness_accounts',
     params: ['lowerBoundName', 'limit']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_witness_count'
   },
+
   {
     api: 'database_api',
     method: 'get_active_witnesses'
   },
+
   {
-    api: 'database_api',
-    method: 'get_miner_queue'
-  },
-  {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_reward_fund',
     params: ['name']
   },
+
   {
-    api: 'database_api',
+    api: 'condenser_api',
     method: 'get_vesting_delegations',
     params: ['account', 'from', 'limit']
   },
+
   {
     api: 'login_api',
     method: 'login',
     params: ['username', 'password']
   },
+
   {
     api: 'login_api',
     method: 'get_api_by_name',
     params: ['database_api']
   },
+
   {
     api: 'login_api',
     method: 'get_version'
   },
+
   {
     api: 'follow_api',
     method: 'get_blog_authors',
     params: ['blogAccount']
   },
+
   {
     api: 'network_broadcast_api',
     method: 'broadcast_transaction',
     params: ['trx']
   },
+
   {
     api: 'network_broadcast_api',
     method: 'broadcast_transaction_with_callback',
     params: ['confirmationCallback', 'trx']
   },
+
   {
     api: 'network_broadcast_api',
     method: 'broadcast_transaction_synchronous',
     params: ['trx']
   },
+
   {
     api: 'network_broadcast_api',
     method: 'broadcast_block',
     params: ['b']
   },
+
   {
     api: 'network_broadcast_api',
     method: 'set_max_block_age',
     params: ['maxBlockAge']
   },
+
   {
     api: 'market_history_api',
     method: 'get_ticker',
     params: []
   },
+
   {
     api: 'market_history_api',
     method: 'get_volume',
     params: []
   },
+
   {
     api: 'market_history_api',
     method: 'get_order_book',
     method_name: 'getMarketOrderBook',
     params: ['limit']
   },
+
   {
     api: 'market_history_api',
     method: 'get_trade_history',
     params: ['start', 'end', 'limit']
   },
+
   {
     api: 'market_history_api',
     method: 'get_recent_trades',
     params: ['limit']
   },
+
   {
     api: 'market_history_api',
     method: 'get_market_history',
     params: ['bucket_seconds', 'start', 'end']
   },
+
   {
     api: 'market_history_api',
     method: 'get_market_history_buckets',
     params: []
   },
+
   {
     api: 'condenser_api',
     method: 'find_proposals',
     params: ['id_set']
   },
+
   {
     api: 'condenser_api',
     method: 'list_proposals',
     params: ['start', 'limit', 'order_by', 'order_direction', 'status']
   },
+
   {
     api: 'condenser_api',
     method: 'list_proposal_votes',
     params: ['start', 'limit', 'order_by', 'order_direction', 'status']
   },
+
   {
     api: 'condenser_api',
     method: 'get_nai_pool',
     params: []
   },
+
   {
     api: 'rc_api',
     method: 'find_rc_accounts',
     params: ['accounts'],
     is_object: true
   },
+
   {
     api: 'condenser_api',
     method: 'get_expiring_vesting_delegations',
     params: ['account', 'start', 'limit'],
   },
+
   {
     api: 'database_api',
     method: 'find_change_recovery_account_requests',
     params: ['account'],
     is_object: true
   },
-  {
-    api: 'database_api',
-    method: 'get_escrow_by_from',
-    params: ['from', 'escrowId']
-  },
-  {
-    api: 'database_api',
-    method: 'get_escrow_by_to',
-    params: ['to', 'escrowId']
-  },
-  {
-    api: 'database_api',
-    method: 'get_escrow_by_agent',
-    params: ['agent', 'escrowId']
-  },
-  {
-    api: 'database_api',
-    method: 'get_account_bandwidth_by_type',
-    params: ['account', 'bandwidthType']
-  },
-  {
-    api: 'database_api',
-    method: 'get_account_bandwidth_by_type_and_time',
-    params: ['account', 'bandwidthType', 'time']
-  },
-  {
-    api: 'database_api',
-    method: 'get_proposed_transactions',
-    params: ['account']
-  },
-  {
-    api: 'database_api',
-    method: 'get_proposed_transaction',
-    params: ['account', 'proposalId']
-  },
-  {
-    api: 'database_api',
-    method: 'get_proposed_transaction_expirations',
-    params: ['account']
-  },
-  {
-    api: 'database_api',
-    method: 'get_proposed_transaction_approvals',
-    params: ['account']
-  },
-  {
-    api: 'database_api',
-    method: 'get_proposed_transaction_approvals_by_id',
-    params: ['proposalId']
-  },
-  {
-    api: 'database_api',
-    method: 'get_proposed_transaction_approvals_by_account',
-    params: ['account']
-  },
-  {
-    api: 'database_api',
-    method: 'get_proposed_transaction_approvals_by_account_and_id',
-    params: ['account', 'proposalId']
-  },
-  {
-    api: 'database_api',
-    method: 'get_proposed_transaction_approvals_by_account_and_time',
-    params: ['account', 'time']
-  },
-  {
-    api: 'database_api',
-    method: 'get_proposed_transaction_approvals_by_account_and_time_and_id',
-    params: ['account', 'time', 'proposalId']
-  },
-  {
-    api: 'database_api',
-    method: 'get_proposed_transaction_approvals_by_account_and_time_and_id_and_approver',
-    params: ['account', 'time', 'proposalId', 'approver']
-  }
 ];
 
 export default methods; 

--- a/src/api/transports/http.ts
+++ b/src/api/transports/http.ts
@@ -135,6 +135,10 @@ export class HttpTransport extends BaseTransport {
     return this.nonRetriableOperations.includes(method);
   }
 
+  /**
+   * POST JSON-RPC to the node. Body uses method `call` with params [api, methodName, args]
+   * for backwards compatibility with steemd; alternatively use Api.call('plugin.method', …).
+   */
   send(api: string, data: { id?: number; method: string; params: unknown[] }, callback?: (err: Error | null, result?: unknown, attempt?: number) => void) {
     if (typeof callback !== 'function') {
       callback = () => {};

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,6 +1,6 @@
 /**
- * Type definitions for dynamically generated API methods
- * These types provide TypeScript support for all API methods
+ * Type definitions for dynamically generated API methods.
+ * Runtime routing (condenser_api vs database_api) is defined in methods.ts; see docs/README.md#api-routing.
  */
 
 // Base callback type


### PR DESCRIPTION
## Summary

Aligns steem-js RPC namespaces with current [steem](https://github.com/steemit/steem) full nodes and documents the change for **v1.0.16**.

- **Fix:** Route 51 legacy `get_*` helpers through **`condenser_api`** (they were incorrectly sent as `database_api`, which causes `Could not find method` on modern nodes).
- **Keep:** 12 helpers on **`database_api`** (`get_config`, `get_dynamic_global_properties`, `verify_authority`, `find_change_recovery_account_requests`, …).
- **Remove:** 30 helpers that no longer exist on the chain (subscriptions, categories, `getDiscussionsByPayout`, proposed-transaction APIs, …).
- **Docs:** [API routing guide](https://github.com/steemit/steem-js/blob/fix/condenser-api-routing/docs/README.md#api-routing), [CHANGELOG](https://github.com/steemit/steem-js/blob/fix/condenser-api-routing/CHANGELOG.md), refactoring §11.

Also includes two commits from local `next` not yet on `origin/next`:

- `chore: bump version to 1.0.15`
- `chore: clean dist before build and add clean script`

## Commits

| Commit | Description |
|--------|-------------|
| `10881c6` | chore: bump version to 1.0.15 |
| `56ecc01` | chore: clean dist before build and add clean script |
| `6f8d77a` | fix(api): route legacy read methods through condenser_api |
| `ae168c3` | docs: document condenser_api vs database_api routing |
| (this PR) | docs: add CHANGELOG |

## Migration

- **No API renames** for surviving helpers (`getAccounts` still works; it now hits `condenser_api.get_accounts` on the wire).
- **Removed methods** — see [removed helpers list](https://github.com/steemit/steem-js/blob/fix/condenser-api-routing/docs/README.md#removed-helpers-v1016). Use `steem.api.callAsync('database_api.find_*', …)` for new-style node APIs.
- **Signed / raw RPC** — use full names, e.g. `condenser_api.get_accounts` (see [signedCall examples](https://github.com/steemit/steem-js/blob/fix/condenser-api-routing/docs/signedCall-examples.md)).

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (249 passed; 9 integration tests failed against public API with `JsonRpcError: Internal Error` — network/node, not routing regression)
- [ ] Smoke-test against a local `steemd` full node: `getAccounts`, `getContent`, `getDynamicGlobalProperties`
- [ ] Confirm `api.call('database_api.find_accounts', …)` for new-style APIs