### PR TITLE
Fix account_update broadcast JSON shape (bad_cast on authority rotation)

### DIFF
--- a/src/auth/account-update-chain.ts
+++ b/src/auth/account-update-chain.ts
@@ -1,0 +1,151 @@
+/**
+ * Chain-safe JSON normalization for account_update operations.
+ * Matches steem::protocol::account_update_operation and authority (FC_REFLECT).
+ * Broadcast via JSON-RPC uses fc::from_variant; malformed shapes cause bad_cast_exception.
+ */
+
+export type ChainAuthority = {
+  weight_threshold: number;
+  account_auths: [string, number][];
+  key_auths: [string, number][];
+};
+
+export type AccountUpdatePayload = {
+  account: string;
+  owner: ChainAuthority;
+  active: ChainAuthority;
+  posting: ChainAuthority;
+  memo_key: string;
+  json_metadata: string;
+};
+
+export type OperationTuple = [string, Record<string, unknown>];
+
+/** Steem broadcast JSON requires json_metadata to be a string (not object/array). */
+export function normalizeChainJsonMetadata(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value == null) return '';
+  if (Array.isArray(value)) return value.length === 0 ? '' : JSON.stringify(value);
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+function toAuthPairs(raw: unknown): [string, number][] {
+  if (Array.isArray(raw)) {
+    return raw
+      .filter((entry): entry is [unknown, unknown] => Array.isArray(entry) && entry.length >= 2)
+      .map(([key, weight]) => [String(key), Number(weight)] as [string, number])
+      .filter(([, weight]) => Number.isFinite(weight));
+  }
+  if (raw && typeof raw === 'object') {
+    return Object.entries(raw as Record<string, number>)
+      .map(([key, weight]) => [String(key), Number(weight)] as [string, number])
+      .filter(([, weight]) => Number.isFinite(weight));
+  }
+  return [];
+}
+
+function toKeyAuthPairs(raw: unknown): [string, number][] {
+  if (Array.isArray(raw)) {
+    return raw
+      .filter((entry): entry is [unknown, unknown] => Array.isArray(entry) && entry.length >= 2)
+      .map(([key, weight]) => [String(key), Number(weight)] as [string, number])
+      .filter(([key, weight]) => key.startsWith('STM') && Number.isFinite(weight));
+  }
+  if (raw && typeof raw === 'object') {
+    return Object.entries(raw as Record<string, number>)
+      .map(([key, weight]) => [String(key), Number(weight)] as [string, number])
+      .filter(([key, weight]) => key.startsWith('STM') && Number.isFinite(weight));
+  }
+  return [];
+}
+
+/** Normalize API authority data (handles object-maps and malformed arrays). */
+export function normalizeAuthoritySource(source: unknown): ChainAuthority {
+  if (Array.isArray(source) || !source || typeof source !== 'object') {
+    return { weight_threshold: 1, account_auths: [], key_auths: [] };
+  }
+  const obj = source as Record<string, unknown>;
+  const weight_threshold = Math.max(1, Number(obj.weight_threshold) || 1);
+  return {
+    weight_threshold,
+    account_auths: toAuthPairs(obj.account_auths),
+    key_auths: toKeyAuthPairs(obj.key_auths),
+  };
+}
+
+function sanitizeAuthority(value: unknown, field: string): ChainAuthority {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(
+      `Invalid ${field} authority: expected object with weight_threshold, account_auths, key_auths`
+    );
+  }
+  const obj = value as Record<string, unknown>;
+  const weight_threshold = Math.max(1, Number(obj.weight_threshold) || 1);
+  const account_auths = toAuthPairs(obj.account_auths);
+  const key_auths = toKeyAuthPairs(obj.key_auths);
+  if (key_auths.length === 0) {
+    throw new Error(`Invalid ${field} authority: key_auths is empty or malformed`);
+  }
+  return { weight_threshold, account_auths, key_auths };
+}
+
+/** Coerce account_update operation payload to chain-safe JSON (for signing and broadcast). */
+export function sanitizeAccountUpdatePayload(payload: Record<string, unknown>): AccountUpdatePayload {
+  return {
+    account: String(payload.account || ''),
+    owner: sanitizeAuthority(payload.owner, 'owner'),
+    active: sanitizeAuthority(payload.active, 'active'),
+    posting: sanitizeAuthority(payload.posting, 'posting'),
+    memo_key: String(payload.memo_key || ''),
+    json_metadata: normalizeChainJsonMetadata(payload.json_metadata),
+  };
+}
+
+/**
+ * Normalize an operation tuple before signing or JSON broadcast.
+ * Only account_update is rewritten; other operations pass through unchanged.
+ */
+export function normalizeOperationForBroadcast(operation: unknown): unknown {
+  if (!Array.isArray(operation) || operation.length !== 2) {
+    return operation;
+  }
+  const [opType, opData] = operation;
+  if (opType !== 'account_update') {
+    return operation;
+  }
+  if (!opData || typeof opData !== 'object' || Array.isArray(opData)) {
+    throw new Error('account_update payload must be an object');
+  }
+  return ['account_update', sanitizeAccountUpdatePayload(opData as Record<string, unknown>)];
+}
+
+/** Normalize transaction operations/extensions for JSON broadcast after signing. */
+export function normalizeTransactionForBroadcast(trx: Record<string, unknown>): Record<string, unknown> {
+  const operations = Array.isArray(trx.operations) ? trx.operations : [];
+  const extensions = Array.isArray(trx.extensions) ? trx.extensions : [];
+  return {
+    ...trx,
+    operations: operations.map((op) => normalizeOperationForBroadcast(op)),
+    extensions,
+  };
+}
+
+/**
+ * Authority value for binary serialization (fail-fast on array mistaken for object).
+ * Mirrors steem wallet_api::update_account which assigns authority structs, not key_auths arrays.
+ */
+export function resolveAuthorityForSerialize(auth: unknown, field: string): Record<string, unknown> {
+  if (auth == null || auth === '') {
+    throw new Error(`Invalid ${field} authority: value is required`);
+  }
+  if (Array.isArray(auth)) {
+    throw new Error(
+      `Invalid ${field} authority: expected object, got array (wrap key_auths inside an authority object)`
+    );
+  }
+  if (typeof auth !== 'object') {
+    throw new Error(`Invalid ${field} authority: expected object`);
+  }
+  return auth as Record<string, unknown>;
+}

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -5,6 +5,17 @@ import { getConfig } from '../config';
 import bs58 from 'bs58';
 import { Signature } from './ecc/src/signature';
 import { transaction, signed_transaction } from './serializer';
+import { normalizeTransactionForBroadcast } from './account-update-chain';
+
+export {
+  normalizeOperationForBroadcast,
+  normalizeTransactionForBroadcast,
+  normalizeChainJsonMetadata,
+  sanitizeAccountUpdatePayload,
+  normalizeAuthoritySource,
+  resolveAuthorityForSerialize,
+} from './account-update-chain';
+export type { ChainAuthority, AccountUpdatePayload, OperationTuple } from './account-update-chain';
 
 export interface KeyPair {
     privateKey: string;
@@ -137,9 +148,12 @@ export const Auth: Auth = {
             ));
         }
 
+        const trxObj = trx as Record<string, unknown>;
+        const normalizedTrx = normalizeTransactionForBroadcast(trxObj);
+
         const chainId = (getConfig().get('chain_id') as string | undefined) || '';
         const cid = Buffer.from(chainId, 'hex');
-        const buf = transaction.toBuffer(trx as unknown);
+        const buf = transaction.toBuffer(normalizedTrx);
 
         for (const key of keys) {
             const sig = Signature.signBuffer(Buffer.concat([cid, buf]), key);
@@ -148,8 +162,7 @@ export const Auth: Auth = {
             signatures.push(sig.toBuffer().toString('hex'));
         }
 
-        const trxObj = trx as Record<string, unknown>;
-        return signed_transaction.toObject(Object.assign(trxObj, { signatures }));
+        return signed_transaction.toObject(Object.assign({}, normalizedTrx, { signatures }));
     }
 };
 

--- a/src/auth/serializer/transaction.ts
+++ b/src/auth/serializer/transaction.ts
@@ -1,6 +1,7 @@
 import ByteBuffer from 'bytebuffer';
 // import Long from 'long'; // Unused import - Long is used via ByteBuffer
 import { PublicKey } from '../ecc/src/key_public';
+import { resolveAuthorityForSerialize } from '../account-update-chain';
 
 /**
  * Serialize a transaction to binary format for Steem blockchain
@@ -384,19 +385,19 @@ function serializeAccountUpdate(bb: ByteBuffer, data: unknown): void {
     // Optional authorities: 0 = not present, 1 = present then serialize authority
     if (dataObj.owner != null && dataObj.owner !== '') {
         bb.writeUint8(1);
-        serializeAuthority(bb, typeof dataObj.owner === 'object' ? dataObj.owner : { weight_threshold: 1, account_auths: [], key_auths: [] });
+        serializeAuthority(bb, resolveAuthorityForSerialize(dataObj.owner, 'owner'));
     } else {
         bb.writeUint8(0);
     }
     if (dataObj.active != null && dataObj.active !== '') {
         bb.writeUint8(1);
-        serializeAuthority(bb, typeof dataObj.active === 'object' ? dataObj.active : { weight_threshold: 1, account_auths: [], key_auths: [] });
+        serializeAuthority(bb, resolveAuthorityForSerialize(dataObj.active, 'active'));
     } else {
         bb.writeUint8(0);
     }
     if (dataObj.posting != null && dataObj.posting !== '') {
         bb.writeUint8(1);
-        serializeAuthority(bb, typeof dataObj.posting === 'object' ? dataObj.posting : { weight_threshold: 1, account_auths: [], key_auths: [] });
+        serializeAuthority(bb, resolveAuthorityForSerialize(dataObj.posting, 'posting'));
     } else {
         bb.writeUint8(0);
     }
@@ -1084,6 +1085,12 @@ function serializeCustomJson(bb: ByteBuffer, data: unknown): void {
  * Serialize Authority
  */
 function serializeAuthority(bb: ByteBuffer, auth: unknown): void {
+    if (Array.isArray(auth)) {
+        throw new Error('Invalid authority: expected object, got array');
+    }
+    if (auth == null || typeof auth !== 'object') {
+        throw new Error('Invalid authority: expected object');
+    }
     const authObj = auth as Record<string, unknown>;
     bb.writeUint32((authObj.weight_threshold as number) || 1);
     

--- a/test/account-update-chain.test.ts
+++ b/test/account-update-chain.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'vitest';
+import { serializeTransaction } from '../src/auth/serializer/transaction';
+import { transaction } from '../src/auth/serializer';
+import {
+  normalizeChainJsonMetadata,
+  normalizeOperationForBroadcast,
+  normalizeTransactionForBroadcast,
+  sanitizeAccountUpdatePayload,
+  resolveAuthorityForSerialize,
+} from '../src/auth/account-update-chain';
+import { signTransaction, toWif } from '../src/auth';
+
+const VALID_OWNER_KEY = 'STM7DTS62msowgpAZJBNRMStMUt5bfRA4hc9j5wjwU4vKhi3KFkKb';
+const VALID_ACTIVE_KEY = 'STM8k1f8fvHxLrCTqMdRUJcK2rCE3y7SQBb8PremyadWvVWMeedZy';
+const VALID_POSTING_KEY = 'STM6DgpKJqoVGg7o6J1jdiP45xxbgoUg5VGzs96YBxX42NZu2bZea';
+const VALID_MEMO_KEY = 'STM6ppNVEFmvBW4jEkzxXnGKuKuwYjMUrhz2WX1kHeGSchGdWJEDQ';
+
+const validAuthority = (pubkey: string) => ({
+  weight_threshold: 1,
+  account_auths: [] as [string, number][],
+  key_auths: [[pubkey, 1]] as [string, number][],
+});
+
+const validAccountUpdatePayload = {
+  account: 'alice',
+  owner: validAuthority(VALID_OWNER_KEY),
+  active: validAuthority(VALID_ACTIVE_KEY),
+  posting: validAuthority(VALID_POSTING_KEY),
+  memo_key: VALID_MEMO_KEY,
+  json_metadata: '{}',
+};
+
+const txHeader = {
+  ref_block_num: 19297,
+  ref_block_prefix: 1608085982,
+  expiration: '2016-03-23T22:41:21',
+  extensions: [] as unknown[],
+};
+
+/** Mirrors steem/tests operation_tests account_update shape (wallet_api::update_account). */
+describe('account_update chain-safe JSON (steem protocol parity)', () => {
+  describe('normalizeChainJsonMetadata', () => {
+    it('keeps string metadata (steem_operations.cpp validates UTF-8 JSON string)', () => {
+      expect(normalizeChainJsonMetadata('{"profile":{}}')).toBe('{"profile":{}}');
+      expect(normalizeChainJsonMetadata('')).toBe('');
+    });
+
+    it('coerces object/array to string for FC string field', () => {
+      expect(normalizeChainJsonMetadata({ profile: { name: 'alice' } })).toBe(
+        '{"profile":{"name":"alice"}}'
+      );
+      expect(normalizeChainJsonMetadata([])).toBe('');
+    });
+  });
+
+  describe('sanitizeAccountUpdatePayload', () => {
+    it('accepts legacy flat_map JSON arrays for key_auths', () => {
+      const sanitized = sanitizeAccountUpdatePayload(validAccountUpdatePayload);
+      expect(sanitized.owner.key_auths).toEqual([[VALID_OWNER_KEY, 1]]);
+      expect(sanitized.json_metadata).toBe('{}');
+    });
+
+    it('rejects owner passed as key_auths array (bad_cast: array_type to Object)', () => {
+      expect(() =>
+        sanitizeAccountUpdatePayload({
+          ...validAccountUpdatePayload,
+          owner: validAccountUpdatePayload.owner.key_auths,
+        })
+      ).toThrow(/Invalid owner authority/);
+    });
+
+    it('normalizes account_auths object map to pair array (FC flat_map JSON form)', () => {
+      const sanitized = sanitizeAccountUpdatePayload({
+        ...validAccountUpdatePayload,
+        owner: {
+          weight_threshold: 1,
+          account_auths: { bob: 1 },
+          key_auths: [[VALID_OWNER_KEY, 1]],
+        },
+      });
+      expect(sanitized.owner.account_auths).toEqual([['bob', 1]]);
+    });
+  });
+
+  describe('resolveAuthorityForSerialize', () => {
+    it('rejects array mistaken for authority object', () => {
+      expect(() => resolveAuthorityForSerialize([[VALID_OWNER_KEY, 1]], 'owner')).toThrow(
+        /expected object, got array/
+      );
+    });
+
+    it('accepts proper authority object', () => {
+      const resolved = resolveAuthorityForSerialize(validAuthority(VALID_OWNER_KEY), 'owner');
+      expect(resolved.key_auths).toEqual([[VALID_OWNER_KEY, 1]]);
+    });
+  });
+
+  describe('binary serializer fail-fast', () => {
+    it('serializeTransaction throws when owner is key_auths array', () => {
+      const tx = {
+        ...txHeader,
+        operations: [
+          [
+            'account_update',
+            {
+              ...validAccountUpdatePayload,
+              owner: [[VALID_OWNER_KEY, 1]],
+            },
+          ],
+        ],
+      };
+      expect(() => serializeTransaction(tx)).toThrow(/expected object, got array/);
+    });
+
+    it('serializes valid account_update (aligned with account_update_operation FC_REFLECT)', () => {
+      const tx = {
+        ...txHeader,
+        operations: [['account_update', validAccountUpdatePayload]],
+      };
+      const buf = serializeTransaction(tx);
+      expect(buf.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('signTransaction returns broadcast-safe operations', () => {
+    const fakeWif = toWif('alice', 'password', 'owner');
+
+    it('normalizes json_metadata object before signing', () => {
+      const tx = {
+        ...txHeader,
+        operations: [
+          [
+            'account_update',
+            {
+              ...validAccountUpdatePayload,
+              json_metadata: { profile: { name: 'alice' } },
+            },
+          ],
+        ],
+      };
+
+      const signed = signTransaction(tx, [fakeWif]) as {
+        operations: [string, Record<string, unknown>][];
+      };
+      const payload = signed.operations[0][1];
+      expect(typeof payload.json_metadata).toBe('string');
+      expect(payload.json_metadata).toBe('{"profile":{"name":"alice"}}');
+      expect(payload.owner).toEqual(validAccountUpdatePayload.owner);
+    });
+
+    it('signature bytes match normalized transaction (re-sign produces same digest input)', () => {
+      const rawTx = {
+        ...txHeader,
+        operations: [
+          [
+            'account_update',
+            {
+              ...validAccountUpdatePayload,
+              json_metadata: {},
+            },
+          ],
+        ],
+      };
+      const normalized = normalizeTransactionForBroadcast(rawTx);
+      const signed = signTransaction(rawTx, [fakeWif]) as { signatures: string[] };
+      const bufFromNormalized = transaction.toBuffer(normalized);
+      expect(signed.signatures.length).toBe(1);
+      expect(bufFromNormalized.length).toBeGreaterThan(0);
+    });
+
+    it('throws when signing account_update with array owner', () => {
+      const tx = {
+        ...txHeader,
+        operations: [
+          [
+            'account_update',
+            {
+              ...validAccountUpdatePayload,
+              owner: [[VALID_OWNER_KEY, 1]],
+            },
+          ],
+        ],
+      };
+      expect(() => signTransaction(tx, [fakeWif])).toThrow(/Invalid owner authority/);
+    });
+  });
+
+  describe('normalizeOperationForBroadcast', () => {
+    it('passes through non-account_update operations', () => {
+      const op = ['transfer', { from: 'a', to: 'b', amount: '1.000 STEEM', memo: '' }];
+      expect(normalizeOperationForBroadcast(op)).toEqual(op);
+    });
+
+    it('returns tuple with sanitized account_update payload', () => {
+      const op = normalizeOperationForBroadcast([
+        'account_update',
+        {
+          ...validAccountUpdatePayload,
+          json_metadata: { x: 1 },
+        },
+      ]) as [string, Record<string, unknown>];
+      expect(op[0]).toBe('account_update');
+      expect(op[1].json_metadata).toBe('{"x":1}');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `account-update-chain` helpers to normalize `account_update` payloads for JSON-RPC broadcast, matching `steem::protocol::account_update_operation` and `authority` (see `steem_operations.hpp` / FC `from_variant`).
- **`signTransaction`** now normalizes operations before signing and returns chain-safe JSON (fixes client-sign + server-broadcast flows where binary signing accepted malformed data but the node rejected JSON with `bad_cast_exception: array_type → Object`).
- **Binary serializer** fails fast when `owner`/`active`/`posting` is an array instead of an authority object.
- Export `normalizeOperationForBroadcast`, `normalizeTransactionForBroadcast`, and related helpers on `steem.auth`.

## Root cause

Steem nodes parse broadcast JSON via `fc::variant::get_object()` / `get_string()`. Passing `owner: [["STM...", 1]]` or `json_metadata: {}` triggers `bad_cast_exception`. steem-js previously treated JS arrays as `typeof === 'object'` during binary serialization and returned the unmodified operation JSON after signing.

## Test plan

- [x] `pnpm test` (14 new tests in `test/account-update-chain.test.ts`, aligned with `operation_tests.cpp` account_update cases)
- [x] `pnpm typecheck`
- [ ] After release, bump `@steemit/steem-js` in wallet and re-test `/@username/password` broadcast