### PR TITLE
fix(auth): align account_update authority types with steem fc::flat_map JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.19] - 2026-05-24
+
+### Fixed
+
+- Align **`account_update`** authority types with Steem **`fc::flat_map`** JSON: broadcast **`key_auths`** / **`account_auths`** as **`[key, weight]`** pair arrays (not object maps), matching `fc::from_variant` in `fc/container/flat.hpp` (#538).
+- Coerce mistaken object-map authority input into pair arrays before signing and broadcast.
+
+### Added
+
+- Export **`AuthorityWeightPair`**; document protocol shapes on **`ChainAuthority`** and **`AccountUpdatePayload`**.
+- Binary serializer accepts pair arrays and object maps for authority maps; parity test for normalized vs raw transaction bytes.
+
 ## [1.0.18] - 2026-05-23
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steemit/steem-js",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Steem blockchain JavaScript/TypeScript library",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/auth/account-update-chain.ts
+++ b/src/auth/account-update-chain.ts
@@ -1,15 +1,40 @@
 /**
- * Chain-safe JSON normalization for account_update operations.
- * Matches steem::protocol::account_update_operation and authority (FC_REFLECT).
- * Broadcast via JSON-RPC uses fc::from_variant; malformed shapes cause bad_cast_exception.
+ * Chain-safe JSON normalization for `account_update` operations.
+ *
+ * Protocol types (steem/libraries/protocol):
+ * - `authority` — weight_threshold (uint32), account_auths / key_auths (fc::flat_map)
+ * - `account_update_operation` — account, optional owner/active/posting, memo_key, json_metadata (string)
+ *
+ * JSON-RPC (`condenser_api.broadcast_transaction` → fc::from_variant):
+ * - `authority` is a variant_object, not a bare key_auths array.
+ * - `fc::flat_map` serializes as an array of [key, weight] pairs (see fc/container/flat.hpp),
+ *   not a JSON object `{ "key": weight }` — object maps cause bad_cast_exception.
+ * - `json_metadata` must be a string (protocol `string`), not a parsed JSON object.
+ *
+ * Binary signing (transaction digest) uses the same logical fields; the serializer packs
+ * flat_maps as sorted on-wire maps (see serializeAuthority in serializer/transaction.ts).
  */
 
+/** One entry in an fc::flat_map after JSON (de)serialization: [key, weight]. */
+export type AuthorityWeightPair = [string, number];
+
+/**
+ * `steem::protocol::authority` as returned by condenser / required for broadcast JSON.
+ * account_auths: flat_map<account_name_type, uint16>
+ * key_auths: flat_map<public_key_type, uint16> (keys are "STM..." strings in JSON)
+ */
 export type ChainAuthority = {
   weight_threshold: number;
-  account_auths: [string, number][];
-  key_auths: [string, number][];
+  /** FC flat_map JSON: `[["account", weight], ...]` */
+  account_auths: AuthorityWeightPair[];
+  /** FC flat_map JSON: `[["STM...", weight], ...]` */
+  key_auths: AuthorityWeightPair[];
 };
 
+/**
+ * `steem::protocol::account_update_operation` payload for JSON broadcast and signing.
+ * Operation tuple form: `["account_update", AccountUpdatePayload]`.
+ */
 export type AccountUpdatePayload = {
   account: string;
   owner: ChainAuthority;
@@ -21,7 +46,10 @@ export type AccountUpdatePayload = {
 
 export type OperationTuple = [string, Record<string, unknown>];
 
-/** Steem broadcast JSON requires json_metadata to be a string (not object/array). */
+/**
+ * Coerce `json_metadata` to protocol `string` (FC string field).
+ * Node rejects object/array variants with bad_cast when broadcasting.
+ */
 export function normalizeChainJsonMetadata(value: unknown): string {
   if (typeof value === 'string') return value;
   if (value == null) return '';
@@ -30,37 +58,41 @@ export function normalizeChainJsonMetadata(value: unknown): string {
   return String(value);
 }
 
-function toAuthPairs(raw: unknown): [string, number][] {
+/**
+ * Parse fc::flat_map JSON (pair array) or mistaken object-map input into pair arrays.
+ * Broadcast output always uses pair arrays per fc::from_variant(flat_map).
+ */
+function toAuthPairs(raw: unknown): AuthorityWeightPair[] {
   if (Array.isArray(raw)) {
     return raw
       .filter((entry): entry is [unknown, unknown] => Array.isArray(entry) && entry.length >= 2)
-      .map(([key, weight]) => [String(key), Number(weight)] as [string, number])
+      .map(([key, weight]) => [String(key), Number(weight)] as AuthorityWeightPair)
       .filter(([, weight]) => Number.isFinite(weight));
   }
   if (raw && typeof raw === 'object') {
     return Object.entries(raw as Record<string, number>)
-      .map(([key, weight]) => [String(key), Number(weight)] as [string, number])
+      .map(([key, weight]) => [String(key), Number(weight)] as AuthorityWeightPair)
       .filter(([, weight]) => Number.isFinite(weight));
   }
   return [];
 }
 
-function toKeyAuthPairs(raw: unknown): [string, number][] {
+function toKeyAuthPairs(raw: unknown): AuthorityWeightPair[] {
   if (Array.isArray(raw)) {
     return raw
       .filter((entry): entry is [unknown, unknown] => Array.isArray(entry) && entry.length >= 2)
-      .map(([key, weight]) => [String(key), Number(weight)] as [string, number])
+      .map(([key, weight]) => [String(key), Number(weight)] as AuthorityWeightPair)
       .filter(([key, weight]) => key.startsWith('STM') && Number.isFinite(weight));
   }
   if (raw && typeof raw === 'object') {
     return Object.entries(raw as Record<string, number>)
-      .map(([key, weight]) => [String(key), Number(weight)] as [string, number])
+      .map(([key, weight]) => [String(key), Number(weight)] as AuthorityWeightPair)
       .filter(([key, weight]) => key.startsWith('STM') && Number.isFinite(weight));
   }
   return [];
 }
 
-/** Normalize API authority data (handles object-maps and malformed arrays). */
+/** Normalize API authority data (get_accounts-style input; accepts pair arrays or object maps). */
 export function normalizeAuthoritySource(source: unknown): ChainAuthority {
   if (Array.isArray(source) || !source || typeof source !== 'object') {
     return { weight_threshold: 1, account_auths: [], key_auths: [] };
@@ -90,7 +122,10 @@ function sanitizeAuthority(value: unknown, field: string): ChainAuthority {
   return { weight_threshold, account_auths, key_auths };
 }
 
-/** Coerce account_update operation payload to chain-safe JSON (for signing and broadcast). */
+/**
+ * Coerce account_update operation payload to protocol JSON shape for signing and broadcast.
+ * Emits fc::flat_map fields as pair arrays, not object maps.
+ */
 export function sanitizeAccountUpdatePayload(payload: Record<string, unknown>): AccountUpdatePayload {
   return {
     account: String(payload.account || ''),

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -15,7 +15,12 @@ export {
   normalizeAuthoritySource,
   resolveAuthorityForSerialize,
 } from './account-update-chain';
-export type { ChainAuthority, AccountUpdatePayload, OperationTuple } from './account-update-chain';
+export type {
+  AuthorityWeightPair,
+  ChainAuthority,
+  AccountUpdatePayload,
+  OperationTuple,
+} from './account-update-chain';
 
 export interface KeyPair {
     privateKey: string;

--- a/src/auth/serializer/transaction.ts
+++ b/src/auth/serializer/transaction.ts
@@ -375,8 +375,9 @@ function serializeAccountCreate(bb: ByteBuffer, data: unknown): void {
 }
 
 /**
- * Serialize account_update operation.
- * Format: account, optional owner (1 byte + authority?), optional active, optional posting, memo_key, json_metadata.
+ * Serialize account_update_operation (steem_operations.hpp).
+ * JSON fields: account, owner/active/posting (authority objects), memo_key, json_metadata (string).
+ * Optional authorities use a presence byte before serializeAuthority.
  */
 function serializeAccountUpdate(bb: ByteBuffer, data: unknown): void {
     const dataObj = data as Record<string, unknown>;
@@ -1082,7 +1083,27 @@ function serializeCustomJson(bb: ByteBuffer, data: unknown): void {
 }
 
 /**
- * Serialize Authority
+ * Read authority map fields for binary packing (on-wire sorted flat_map).
+ * JSON-RPC uses fc::flat_map → array of [key, weight] pairs; object maps are accepted
+ * here only so callers that forgot to normalize still sign the intended keys.
+ */
+function authorityMapEntries(raw: unknown): [string, number][] {
+    if (Array.isArray(raw)) {
+        return raw
+            .filter((entry): entry is [unknown, unknown] => Array.isArray(entry) && entry.length >= 2)
+            .map(([key, weight]) => [String(key), Number(weight)] as [string, number])
+            .filter(([, weight]) => Number.isFinite(weight));
+    }
+    if (raw && typeof raw === 'object') {
+        return Object.entries(raw as Record<string, number>)
+            .map(([key, weight]) => [String(key), Number(weight)] as [string, number])
+            .filter(([, weight]) => Number.isFinite(weight));
+    }
+    return [];
+}
+
+/**
+ * Serialize steem::protocol::authority (weight_threshold + sorted account/key flat_maps).
  */
 function serializeAuthority(bb: ByteBuffer, auth: unknown): void {
     if (Array.isArray(auth)) {
@@ -1095,43 +1116,26 @@ function serializeAuthority(bb: ByteBuffer, auth: unknown): void {
     bb.writeUint32((authObj.weight_threshold as number) || 1);
     
     // Account auths (map<string, uint16>)
-    const accountAuths = (Array.isArray(authObj.account_auths) ? authObj.account_auths : []) as unknown[][];
-    // Maps in Steem serialization are sorted by key
-    const accountAuthsArray = accountAuths as unknown[][];
-    accountAuthsArray.sort((a: unknown[], b: unknown[]) => {
-      const aKey = Array.isArray(a) && a[0] ? String(a[0]) : '';
-      const bKey = Array.isArray(b) && b[0] ? String(b[0]) : '';
-      return aKey.localeCompare(bKey);
-    });
+    const accountAuths = authorityMapEntries(authObj.account_auths).sort((a, b) =>
+        a[0].localeCompare(b[0])
+    );
     
     bb.writeVarint32(accountAuths.length);
-    for (const authEntry of accountAuths) {
-        if (Array.isArray(authEntry) && authEntry.length >= 2) {
-            writeString(bb, String(authEntry[0]));
-            bb.writeUint16(authEntry[1] as number);
-        }
+    for (const [account, weight] of accountAuths) {
+        writeString(bb, account);
+        bb.writeUint16(weight);
     }
     
     // Key auths (map<public_key, uint16>)
-    const keyAuths = (Array.isArray(authObj.key_auths) ? authObj.key_auths : []) as unknown[][];
-    // Maps in Steem serialization are sorted by key (public key string)
-    // But serialized as bytes. Usually sorting by string representation of public key works.
-    const keyAuthsArray = keyAuths as unknown[][];
-    keyAuthsArray.sort((a: unknown[], b: unknown[]) => {
-      const aKey = Array.isArray(a) && a[0] ? String(a[0]) : '';
-      const bKey = Array.isArray(b) && b[0] ? String(b[0]) : '';
-      return aKey.localeCompare(bKey);
-    });
+    const keyAuths = authorityMapEntries(authObj.key_auths).sort((a, b) =>
+        a[0].localeCompare(b[0])
+    );
     
     bb.writeVarint32(keyAuths.length);
-    for (const keyAuth of keyAuths) {
-        if (Array.isArray(keyAuth) && keyAuth.length >= 2) {
-            const keyStr = String(keyAuth[0]);
-            const weight = keyAuth[1] as number;
+    for (const [keyStr, weight] of keyAuths) {
         const pubKey = PublicKey.fromStringOrThrow(keyStr);
         bb.append(pubKey.toBuffer());
         bb.writeUint16(weight);
-        }
     }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,10 @@ export interface Account {
   // Add other account properties as needed
 }
 
+/**
+ * steem::protocol::authority (condenser JSON).
+ * account_auths / key_auths are fc::flat_map → array of [key, weight] pairs, not object maps.
+ */
 export interface Authority {
   weight_threshold: number;
   account_auths: [string, number][];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -75,6 +75,10 @@ export interface Account {
   blog_category: unknown;
 }
 
+/**
+ * steem::protocol::authority (condenser JSON).
+ * account_auths / key_auths are fc::flat_map → array of [key, weight] pairs, not object maps.
+ */
 export interface Authority {
   weight_threshold: number;
   account_auths: [string, number][];

--- a/test/account-update-chain.test.ts
+++ b/test/account-update-chain.test.ts
@@ -54,7 +54,7 @@ describe('account_update chain-safe JSON (steem protocol parity)', () => {
   });
 
   describe('sanitizeAccountUpdatePayload', () => {
-    it('accepts legacy flat_map JSON arrays for key_auths', () => {
+    it('outputs fc::flat_map JSON as pair arrays (not object maps)', () => {
       const sanitized = sanitizeAccountUpdatePayload(validAccountUpdatePayload);
       expect(sanitized.owner.key_auths).toEqual([[VALID_OWNER_KEY, 1]]);
       expect(sanitized.json_metadata).toBe('{}');
@@ -69,7 +69,7 @@ describe('account_update chain-safe JSON (steem protocol parity)', () => {
       ).toThrow(/Invalid owner authority/);
     });
 
-    it('normalizes account_auths object map to pair array (FC flat_map JSON form)', () => {
+    it('normalizes mistaken object-map account_auths to pair arrays', () => {
       const sanitized = sanitizeAccountUpdatePayload({
         ...validAccountUpdatePayload,
         owner: {
@@ -79,6 +79,18 @@ describe('account_update chain-safe JSON (steem protocol parity)', () => {
         },
       });
       expect(sanitized.owner.account_auths).toEqual([['bob', 1]]);
+    });
+
+    it('normalizes mistaken object-map key_auths to pair arrays', () => {
+      const sanitized = sanitizeAccountUpdatePayload({
+        ...validAccountUpdatePayload,
+        owner: {
+          weight_threshold: 1,
+          account_auths: [],
+          key_auths: { [VALID_OWNER_KEY]: 1 },
+        },
+      });
+      expect(sanitized.owner.key_auths).toEqual([[VALID_OWNER_KEY, 1]]);
     });
   });
 
@@ -120,6 +132,17 @@ describe('account_update chain-safe JSON (steem protocol parity)', () => {
       const buf = serializeTransaction(tx);
       expect(buf.length).toBeGreaterThan(0);
     });
+
+    it('tuple-shaped broadcast JSON and normalized payload produce identical binary', () => {
+      const tx = {
+        ...txHeader,
+        operations: [['account_update', validAccountUpdatePayload]],
+      };
+      const normalized = normalizeTransactionForBroadcast(tx);
+      const bufRaw = serializeTransaction(tx);
+      const bufNorm = serializeTransaction(normalized);
+      expect(Buffer.compare(bufRaw, bufNorm)).toBe(0);
+    });
   });
 
   describe('signTransaction returns broadcast-safe operations', () => {
@@ -145,7 +168,11 @@ describe('account_update chain-safe JSON (steem protocol parity)', () => {
       const payload = signed.operations[0][1];
       expect(typeof payload.json_metadata).toBe('string');
       expect(payload.json_metadata).toBe('{"profile":{"name":"alice"}}');
-      expect(payload.owner).toEqual(validAccountUpdatePayload.owner);
+      expect(payload.owner).toEqual({
+        weight_threshold: 1,
+        account_auths: [],
+        key_auths: [[VALID_OWNER_KEY, 1]],
+      });
     });
 
     it('signature bytes match normalized transaction (re-sign produces same digest input)', () => {
@@ -191,7 +218,7 @@ describe('account_update chain-safe JSON (steem protocol parity)', () => {
       expect(normalizeOperationForBroadcast(op)).toEqual(op);
     });
 
-    it('returns tuple with sanitized account_update payload', () => {
+    it('returns tuple with sanitized account_update payload (fc::flat_map pair arrays)', () => {
       const op = normalizeOperationForBroadcast([
         'account_update',
         {
@@ -201,6 +228,9 @@ describe('account_update chain-safe JSON (steem protocol parity)', () => {
       ]) as [string, Record<string, unknown>];
       expect(op[0]).toBe('account_update');
       expect(op[1].json_metadata).toBe('{"x":1}');
+      const owner = op[1].owner as { key_auths: unknown };
+      expect(Array.isArray(owner.key_auths)).toBe(true);
+      expect(owner.key_auths).toEqual([[VALID_OWNER_KEY, 1]]);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Document Steem protocol shapes for `account_update` / `authority` in `account-update-chain.ts` (fc::flat_map → pair arrays in JSON-RPC, `json_metadata` as string).
- Export `AuthorityWeightPair` and clarify `ChainAuthority` / `AccountUpdatePayload` types.
- `sanitizeAccountUpdatePayload` always emits `[key, weight]` pair arrays for broadcast (not `{ key: weight }` object maps, which cause `bad_cast_exception` per `fc/container/flat.hpp`).
- Coerce mistaken object-map input from clients into pair arrays before signing/broadcast.
- `serializeAuthority` accepts both pair arrays and object maps for binary signing; add protocol comments and binary parity test.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (including `test/account-update-chain.test.ts`, 16 tests)
- [x] `pnpm build`