### PR TITLE
fix(auth): verifyTransaction validates against binary digest; export serializeTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.20] - 2026-07-15
+
+### Fixed
+
+- **`steem.auth.verifyTransaction`** now verifies signatures against the correct binary digest `sha256(chain_id ‖ serializeTransaction(normalizedTrx))`, mirroring `signTransaction`'s digest exactly. Previously it verified against `Buffer.from(JSON.stringify(transaction))`, which never matched the signed digest and caused it to return `false` for every legitimately-signed transaction — making the function unusable. The `signatures` field is excluded from the digest (matching signing-time behavior, since `signTransaction` serializes before attaching signatures).
+
+### Added
+
+- Export **`serializeTransaction`** from `steem.auth` so downstream apps (e.g. wallet relay services) can reconstruct the signing digest themselves for server-side signature verification. Type declarations are emitted automatically by the TypeScript build.
+
+### Docs
+
+- Update the Authentication and Transaction serialization sections in `docs/README.md` with `verifyTransaction` / `serializeTransaction` entries and runnable examples.
+- Add a **"Transaction Signature Verification"** section to `docs/signature-verification-examples.md`, covering the sign→verify round-trip, the server-side relay verification use case, rejected cases, and manual digest construction.
+
 ## [1.0.19] - 2026-05-24
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -1896,7 +1896,12 @@ Broadcast and signing use a **binary transaction format** compatible with the St
 
 **Usage**
 
-- **For signing / digest**: `steem.auth.transaction.toBuffer(trx)` — returns the buffer that is hashed for the signature. Same as the exported `serializeTransaction(trx)` from `@steemit/steem-js` auth serializer.
+- **For signing / digest**: `steem.auth.serializeTransaction(trx)` — returns the `Buffer` that is hashed for the signature. This is the public API for the binary serializer; `steem.auth.transaction.toBuffer(trx)` is the equivalent internal entry point.
+
+```javascript
+// The public serializer (preferred for app code):
+const buf = steem.auth.serializeTransaction(trx); // Buffer
+```
 - **Transaction shape**: `trx` must include `ref_block_num`, `ref_block_prefix`, `expiration`, `operations` (array of `[opType, opData]`), and optionally `extensions` and `signatures`.
 
 **Serializer coverage**
@@ -1967,8 +1972,84 @@ steem.auth.wifToPublic(privWif);
 
 ### Sign Transaction
 
+Signs a transaction with the provided private keys. The signature is computed
+over the digest `sha256(chain_id ‖ serializeTransaction(normalizedTrx))`, where
+`chain_id` comes from the configured chain (default all-zero for mainnet).
+
+- **`trx`** — transaction object: `ref_block_num`, `ref_block_prefix`,
+  `expiration`, `operations` (array of `[opType, opData]`), and `extensions`.
+- **`keys`** — array of WIF private keys used to sign.
+- Returns a transaction object with a `signatures` array appended.
+
 ```javascript
-steem.auth.signTransaction(trx, keys);
+const wif = '5JLw5dgQAx6rhZEgNN5C2ds1V47RweGshynFSWFbaMohsYsBvE8';
+const tx = {
+  ref_block_num: 123,
+  ref_block_prefix: 456789,
+  expiration: '2026-07-10T00:00:00',
+  operations: [['transfer', {
+    from: 'alice', to: 'bob', amount: '1.000 STEEM', memo: ''
+  }]],
+  extensions: [],
+};
+
+const signedTx = steem.auth.signTransaction(tx, [wif]);
+console.log(signedTx.signatures); // ['1f23...']  (hex signatures)
+```
+
+> **Note:** the `signatures` field is **not** part of the signed digest. Signing
+> serializes the transaction *before* attaching signatures, so the digest covers
+> only the unsigned transaction body.
+
+### Verify Transaction
+
+Verifies that a signed transaction's signatures were produced by the given
+public key. The digest is reconstructed exactly as `signTransaction` computes
+it: `sha256(chain_id ‖ serializeTransaction(normalizedTrx))`. Returns `true` if
+any signature is valid for `publicKey`, otherwise `false`.
+
+- **`transaction`** — a signed transaction object (must contain a `signatures`
+  array). The `signatures` field is stripped before digest calculation, so it
+  does not matter how many signatures are present.
+- **`publicKey`** — the `STM…` public key to verify against.
+- Returns `boolean`.
+
+```javascript
+const publicKey = steem.auth.wifToPublic(wif);
+
+// Round-trip: a correctly-signed tx verifies against its signing key
+const isValid = steem.auth.verifyTransaction(signedTx, publicKey);
+console.log(isValid); // true
+
+// A different public key is rejected
+const wrongPub = steem.auth.wifToPublic('5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3');
+console.log(steem.auth.verifyTransaction(signedTx, wrongPub)); // false
+```
+
+> **Security use case:** a relay/wallet server can call `verifyTransaction` on a
+> client-submitted transaction to prove — *before* forwarding it to the chain —
+> that it was signed by a key belonging to the claimed account. This closes a
+> defense-in-depth gap where the server previously could only check transaction
+> shape, not cryptographic authenticity.
+
+### Serialize Transaction
+
+Serializes a transaction to its **binary** form (FC-style), returning a `Buffer`.
+This is the same serializer used internally by `signTransaction`, so the output
+matches the Steem node's transaction wire format byte-for-byte. Downstream apps
+can use it to reconstruct the signing digest themselves.
+
+- **`trx`** — transaction object (same shape as `signTransaction`'s `trx`).
+- Returns `Buffer`.
+
+```javascript
+import { sha256 } from '@noble/hashes/sha2';
+
+// Build the exact digest signTransaction signs over:
+const buf = steem.auth.serializeTransaction(tx); // Buffer
+const chainId = Buffer.alloc(32, 0); // mainnet chain_id (all-zero)
+const digest = Buffer.from(sha256(Buffer.concat([chainId, buf])));
+console.log(digest.toString('hex')); // 32-byte digest
 ```
 
 ---

--- a/docs/any-type-analysis.md
+++ b/docs/any-type-analysis.md
@@ -138,6 +138,12 @@ signTransaction(trx: Transaction, keys: string[]): Transaction
 - `src/auth/serializer/transaction.ts`: Multiple functions
 - `src/broadcast/index.ts`: Multiple functions
 
+> **Update (1.0.20):** `verifyTransaction(transaction: unknown, publicKey: string):
+> boolean` and the re-exported `serializeTransaction(trx: unknown): Buffer` were
+> added to `src/auth/index.ts` as typed named exports. They remain `unknown`-typed
+> (consistent with `signTransaction`'s current `any`) until the broader typing
+> pass described here is applied; they do not add new `any` usage.
+
 #### 2.2 API Response Types
 **Location**: `src/api/index.ts`, `src/formatter/index.ts`
 

--- a/docs/signature-verification-examples.md
+++ b/docs/signature-verification-examples.md
@@ -508,7 +508,125 @@ function useMessageAuthSystem() {
 useMessageAuthSystem();
 ```
 
-## Error Handling
+## 6. Transaction Signature Verification
+
+`steem.auth.verifyTransaction(signedTx, publicKey)` verifies that a transaction's
+signatures were produced by the given public key. Unlike the message/RPC-request
+verification above, this operates at the **transaction** level: it reconstructs
+the exact digest `sha256(chain_id ‖ serializeTransaction(trx))` that
+`signTransaction` signs over, then checks each signature against it.
+
+> **Why this matters:** a relay or wallet server can prove a client-submitted
+> transaction was signed by the claimed account's key *before* forwarding it to
+> the chain — closing a defense-in-depth gap that transaction-shape validation
+> alone cannot cover.
+
+### Basic Sign-and-Verify Round-Trip
+
+```javascript
+import { steem } from '@steemit/steem-js';
+
+const wif = '5JLw5dgQAx6rhZEgNN5C2ds1V47RweGshynFSWFbaMohsYsBvE8';
+const publicKey = steem.auth.wifToPublic(wif);
+
+const tx = {
+  ref_block_num: 123,
+  ref_block_prefix: 456789,
+  expiration: '2026-07-10T00:00:00',
+  operations: [['transfer', {
+    from: 'alice', to: 'bob', amount: '1.000 STEEM', memo: ''
+  }]],
+  extensions: [],
+};
+
+// Client signs the transaction locally
+const signedTx = steem.auth.signTransaction(tx, [wif]);
+
+// Server (or same process) verifies it against the public key
+const isValid = steem.auth.verifyTransaction(signedTx, publicKey);
+console.log(isValid ? '✅ Valid signature' : '❌ Invalid signature');
+// => ✅ Valid signature
+```
+
+### Server-Side Verification (Relay Service)
+
+This is the primary security use case: a wallet/relay server receives a
+signed transaction from a client and must independently confirm the signer
+before broadcasting.
+
+```javascript
+import { steem } from '@steemit/steem-js';
+
+/**
+ * Verify a client-submitted transaction before relaying it to the chain.
+ *
+ * @param {object} signedTx  - Transaction signed by the client (has .signatures)
+ * @param {string} publicKey - The STM... public key the server expects the
+ *                             account to sign with (e.g. fetched from get_accounts).
+ * @returns {boolean} true if the signature is cryptographically valid.
+ */
+function verifyClientTransaction(signedTx, publicKey) {
+  if (!signedTx || !Array.isArray(signedTx.signatures) || signedTx.signatures.length === 0) {
+    console.error('❌ Transaction has no signatures');
+    return false;
+  }
+
+  const isValid = steem.auth.verifyTransaction(signedTx, publicKey);
+  if (!isValid) {
+    console.error('❌ Signature does not match the claimed public key');
+    return false;
+  }
+
+  console.log('✅ Transaction signed by the claimed key — safe to relay');
+  return true;
+}
+
+// Usage in a relay route:
+//   const account = await steem.api.getAccountsAsync([username]);
+//   const expectedPubKey = account[0].active.key_auths[0][0];
+//   if (!verifyClientTransaction(clientSignedTx, expectedPubKey)) {
+//     return res.status(403).json({ error: 'Invalid signature' });
+//   }
+//   await steem.broadcast.sendAsync(clientSignedTx);
+```
+
+### Rejected Cases
+
+```javascript
+// 1. Wrong public key
+const wrongPub = steem.auth.wifToPublic('5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3');
+console.log(steem.auth.verifyTransaction(signedTx, wrongPub)); // false
+
+// 2. Tampered transaction (operation changed after signing)
+const tampered = JSON.parse(JSON.stringify(signedTx));
+tampered.operations[0][1].amount = '999.000 STEEM';
+console.log(steem.auth.verifyTransaction(tampered, publicKey)); // false
+
+// 3. Missing signatures entirely
+const unsigned = { ...tx };
+console.log(steem.auth.verifyTransaction(unsigned, publicKey)); // false
+```
+
+### Building the Digest Manually with serializeTransaction
+
+For advanced use cases (e.g. verifying with a custom crypto stack), the binary
+serializer is exported as `steem.auth.serializeTransaction(trx)` so you can
+reconstruct the signing digest yourself:
+
+```javascript
+import { steem } from '@steemit/steem-js';
+import { sha256 } from '@noble/hashes/sha2';
+
+// The digest signTransaction signs over:
+const buf = steem.auth.serializeTransaction(tx); // Buffer (binary transaction)
+const chainId = Buffer.alloc(32, 0);             // mainnet chain_id (all-zero)
+const digest = Buffer.from(sha256(Buffer.concat([chainId, buf])));
+console.log('Signing digest:', digest.toString('hex')); // 32-byte hex
+```
+
+> **Note:** `serializeTransaction` does **not** include the `signatures` field in
+> its output when the input lacks one — matching `signTransaction`, which
+> serializes the transaction body *before* attaching signatures.
 
 ### Common Verification Errors
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steemit/steem-js",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Steem blockchain JavaScript/TypeScript library",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -207,16 +207,33 @@ export const verifySignature = (message: string, signature: string, publicKey: s
     }
 };
 
+// Serialize a transaction to its binary form for digest calculation.
+// Alias for transaction.toBuffer() so verifyTransaction mirrors signTransaction's
+// serialization path exactly (signTransaction calls transaction.toBuffer at line 161).
+const serializeTrx = (trx: unknown): Buffer => transaction.toBuffer(trx);
+
 export const verifyTransaction = (transaction: unknown, publicKey: string): boolean => {
     try {
         const pub = PublicKey.fromString(publicKey);
         if (!pub) return false;
-        const serialized = Buffer.from(JSON.stringify(transaction));
         const trx = transaction as { signatures?: string[] };
         if (!trx.signatures || !Array.isArray(trx.signatures)) return false;
+        // Reconstruct the exact digest signTransaction signs over:
+        //   Buffer.concat([chain_id, transaction.toBuffer(normalizedTrx)])
+        // signatures are NOT part of the signed digest — signTransaction serializes
+        // BEFORE attaching signatures — so strip them before serializing, otherwise
+        // serializeTransaction() would emit the signatures array and change the digest.
+        const normalizedTrx = normalizeTransactionForBroadcast(trx as Record<string, unknown>);
+        // Build a copy without the signatures key, so serializeTransaction() does not
+        // emit the signatures array into the digest (signTransaction serializes pre-signature).
+        const trxWithoutSigs: Record<string, unknown> = { ...normalizedTrx };
+        delete trxWithoutSigs.signatures;
+        const chainId = (getConfig().get('chain_id') as string | undefined) || '';
+        const cid = Buffer.from(chainId, 'hex');
+        const buf = serializeTrx(trxWithoutSigs);
         return trx.signatures.some((sig: string) => {
             const signature = Signature.fromHex(sig);
-            return signature.verifyBuffer(serialized, pub);
+            return signature.verifyBuffer(Buffer.concat([cid, buf]), pub);
         });
     } catch {
         return false;
@@ -241,4 +258,8 @@ export const getPrivateKey = (seed: string): string => {
 };
 
 // Add stub for test compatibility
-export const signTransaction = Auth.signTransaction.bind(Auth); 
+export const signTransaction = Auth.signTransaction.bind(Auth);
+
+// Export the binary transaction serializer so downstream apps can reconstruct
+// the signing digest sha256(chain_id || serializeTransaction(trx)) themselves.
+export { serializeTransaction } from './serializer/transaction';

--- a/test/signature-verification.test.ts
+++ b/test/signature-verification.test.ts
@@ -362,4 +362,96 @@ describe('Signature Verification', () => {
       expect(signatureVerification.isSignatureExpired('')).toBe(true);
     });
   });
+
+  describe('Transaction Signature Verification (verifyTransaction)', () => {
+    it('should verify a transaction signed by the matching key', () => {
+      const tx = {
+        ref_block_num: 123,
+        ref_block_prefix: 456789,
+        expiration: '2026-07-10T00:00:00',
+        operations: [['transfer', {
+          from: 'alice', to: 'bob', amount: '1.000 STEEM', memo: ''
+        }]],
+        extensions: [],
+      };
+
+      const signedTx = auth.signTransaction(tx, [testPrivateKey]);
+      expect(signedTx.signatures).toHaveLength(1);
+
+      // Correct public key → valid
+      expect(auth.verifyTransaction(signedTx, testPublicKey)).toBe(true);
+    });
+
+    it('should reject a transaction when verified with the wrong public key', () => {
+      const tx = {
+        ref_block_num: 1,
+        ref_block_prefix: 2,
+        expiration: '2026-07-10T00:00:00',
+        operations: [['vote', {
+          voter: 'alice', author: 'bob', permlink: 'post', weight: 10000
+        }]],
+        extensions: [],
+      };
+
+      const signedTx = auth.signTransaction(tx, [testPrivateKey]);
+      const wrongPub = auth.wifToPublic('5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3');
+
+      expect(auth.verifyTransaction(signedTx, wrongPub)).toBe(false);
+    });
+
+    it('should reject a tampered transaction', () => {
+      const tx = {
+        ref_block_num: 1,
+        ref_block_prefix: 2,
+        expiration: '2026-07-10T00:00:00',
+        operations: [['transfer', {
+          from: 'alice', to: 'bob', amount: '1.000 STEEM', memo: ''
+        }]],
+        extensions: [],
+      };
+
+      const signedTx = auth.signTransaction(tx, [testPrivateKey]) as {
+        operations: unknown[]; signatures: string[];
+      };
+
+      // Tamper with the operation AFTER signing — signature no longer matches the digest
+      signedTx.operations = [['transfer', {
+        from: 'alice', to: 'bob', amount: '999.000 STEEM', memo: ''
+      }]];
+
+      expect(auth.verifyTransaction(signedTx, testPublicKey)).toBe(false);
+    });
+
+    it('should return false for a transaction without signatures', () => {
+      const unsignedTx = {
+        ref_block_num: 1,
+        ref_block_prefix: 2,
+        expiration: '2026-07-10T00:00:00',
+        operations: [['transfer', {
+          from: 'alice', to: 'bob', amount: '1.000 STEEM', memo: ''
+        }]],
+        extensions: [],
+      };
+
+      expect(auth.verifyTransaction(unsignedTx, testPublicKey)).toBe(false);
+    });
+
+    it('should export serializeTransaction as a function returning a Buffer', () => {
+      expect(typeof auth.serializeTransaction).toBe('function');
+
+      const tx = {
+        ref_block_num: 1,
+        ref_block_prefix: 2,
+        expiration: '2026-07-10T00:00:00',
+        operations: [['transfer', {
+          from: 'alice', to: 'bob', amount: '1.000 STEEM', memo: ''
+        }]],
+        extensions: [],
+      };
+
+      const buf = auth.serializeTransaction(tx);
+      expect(Buffer.isBuffer(buf)).toBe(true);
+      expect(buf.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/test/transaction-serializer.test.ts
+++ b/test/transaction-serializer.test.ts
@@ -676,22 +676,29 @@ describe('Transaction Serializer', () => {
       const wif = '5JLw5dgQAx6rhZEgNN5C2ds1V47RweGshynFSWFbaMohsYsBvE8';
       
       // Import auth module
-      const { signTransaction, wifToPublic } = await import('../src/auth');
-      
+      const { signTransaction, wifToPublic, verifyTransaction } = await import('../src/auth');
+
       // Sign the transaction
       const signedTx = signTransaction(tx, [wif]);
-      
+
       // Verify signatures were added
       expect(signedTx.signatures).toBeDefined();
       expect(signedTx.signatures.length).toBe(1);
       expect(typeof signedTx.signatures[0]).toBe('string');
-      
+
       // Get public key from WIF
       const publicKey = wifToPublic(wif);
       expect(publicKey).toBeDefined();
-      
-      // Note: Full verification would require implementing verifyTransaction with correct digest
-      // For now, we verify that signing produces valid signatures
+
+      // Now verify the signature against the correct binary digest
+      // sha256(chain_id || serializeTransaction(trx)). Previously verifyTransaction
+      // validated against JSON.stringify(trx) and always returned false.
+      const isValid = verifyTransaction(signedTx, publicKey);
+      expect(isValid).toBe(true);
+
+      // A different (wrong) public key must be rejected
+      const otherPub = wifToPublic('5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3');
+      expect(verifyTransaction(signedTx, otherPub)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

`steem.auth.verifyTransaction` is currently **broken**: it verifies signatures against `Buffer.from(JSON.stringify(transaction))`, but `signTransaction` signs over `sha256(chain_id ‖ serializeTransaction(normalizedTrx))`. The two never match, so `verifyTransaction` returns `false` for *every* legitimately-signed transaction — making the function unusable and blocking downstream apps (e.g. wallet relay services) from doing server-side signature verification.

This PR fixes `verifyTransaction` to reconstruct the exact signing digest and exports `serializeTransaction` so apps can build the digest themselves.

## Background

This is the upstream fix for the security audit finding tracked in the wallet app (PR #305, deferred item #1: "no server-side signature verification"). The wallet's server cannot cryptographically prove a submitted transaction was signed by the claimed account's key until these two issues are resolved upstream. See `PLAN_steem_js_export_serialize.md` for the full plan.

## Changes

### 1. Fix `verifyTransaction` (`src/auth/index.ts`)

Replaced the wrong JSON-string message with the correct binary digest, mirroring `signTransaction`'s path exactly:

```ts
const chainId = (getConfig().get('chain_id') as string | undefined) || '';
const cid = Buffer.from(chainId, 'hex');
const buf = serializeTrx(trxWithoutSigs); // = transaction.toBuffer(normalizedTrx)
return trx.signatures.some((sig) => {
    const signature = Signature.fromHex(sig);
    return signature.verifyBuffer(Buffer.concat([cid, buf]), pub);
});
```

**Key correctness detail:** `normalizeTransactionForBroadcast` spreads `{...trx}`, which carries the `signatures` key. `serializeTransaction` writes the signatures array into the output when `'signatures' in trxObj` is true — which would change the digest. Since `signTransaction` serializes *before* attaching signatures (signatures are **not** part of the signed digest), `verifyTransaction` strips `signatures` from the object before serializing (`delete trxWithoutSigs.signatures`).

The serialization path (`transaction.toBuffer`) is identical to `signTransaction` (line 161), and `Signature.signBuffer`/`verifyBuffer` are symmetric (both apply `sha256` to the input buffer).

### 2. Export `serializeTransaction` (`src/auth/index.ts`)

```ts
export { serializeTransaction } from './serializer/transaction';
```

Becomes `steem.auth.serializeTransaction(trx): Buffer` via the existing `import * as auth`. Type declarations are emitted automatically by the TypeScript build (`tsconfig` `declaration: true`).

### 3. Tests

- **`test/transaction-serializer.test.ts`**: completed the previously-skipped verification (it had a comment *"Full verification would require implementing verifyTransaction with correct digest"*) into a real sign→verify round-trip + wrong-key rejection.
- **`test/signature-verification.test.ts`**: added 5 tests — correct key accepted, wrong key rejected, tampered transaction rejected, missing signatures rejected, `serializeTransaction` export returns a `Buffer`.

### 4. Docs

- **`docs/README.md`**: filled in the `signTransaction` stub and added `verifyTransaction` / `serializeTransaction` entries (with params + runnable examples) in the Authentication section; corrected the serialization section's `serializeTransaction` reference with a real import example.
- **`docs/signature-verification-examples.md`**: added a **"Transaction Signature Verification"** section covering the sign→verify round-trip, the server-side relay verification use case, rejected cases, and manual digest construction.
- **`docs/any-type-analysis.md`**: noted the new typed exports.

### 5. Version

`1.0.19` → `1.0.20` (+ CHANGELOG entry).

## Security note

This enables defense-in-depth for wallets/relay services that need to prove a transaction was signed by the claimed key *before* forwarding it to the chain — closing the gap that transaction-shape validation alone cannot cover.

## Verification

- [x] `tsc --noEmit` — passes
- [x] `eslint src/auth/index.ts` — passes
- [x] `verifyTransaction(signTransaction(tx, [wif]), pub)` returns `true` (was `false`)
- [x] `verifyTransaction(...)` returns `false` for wrong key / tampered tx / missing signatures
- [x] `typeof steem.auth.serializeTransaction === 'function'` and returns `Buffer`
- [x] `test/serializer-cross-lang.test.ts` — 10/10 pass (no serialization regression)
- [x] Full test suite: 275 pass; only network integration tests fail (timeouts, pre-existing — require a live node)

## What this does NOT change

- `signTransaction` is untouched (its behavior is correct).
- Cross-language serialization fixtures are unchanged.
- Only `serializeTransaction` (the function) is exported; the internal `transaction` serializer object is not.