### PR TITLE
fix(deps): remediate bn.js DoS (CVE-2026-2739) and release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-07-29
+
+### Security
+
+- **Bump `bn.js` to remediate the infinite-loop DoS** ([CVE-2026-2739](https://github.com/advisories/GHSA-378v-28hj-76wf), Dependabot #259 / #260): `maskn(0)` corrupts a `BN`'s internal state, so later `toString()` / `divmod()` calls hang the process. Two copies were affected and both ship inside the published `dist` bundles: the direct dependency (raised to `^5.2.3`, resolving to 5.2.5) and the transitive copy pulled in by `elliptic` (refreshed to 4.12.5). No code path in this package calls `maskn`, so the advisory was not reachable from `steem.auth` itself, but downstream consumers receive `BN` instances through `ECSignature`.
+
 ## [1.1.0] - 2026-07-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steemit/steem-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Steem blockchain JavaScript/TypeScript library",
   "type": "module",
   "main": "dist/index.cjs",
@@ -78,7 +78,7 @@
   "dependencies": {
     "@noble/ciphers": "^2.0.1",
     "@noble/hashes": "^2.0.1",
-    "bn.js": "^5.2.2",
+    "bn.js": "^5.2.3",
     "bs58": "^6.0.0",
     "bytebuffer": "^5.0.1",
     "create-hash": "^1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       bn.js:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.2.3
+        version: 5.2.5
       bs58:
         specifier: ^6.0.0
         version: 6.0.0
@@ -89,13 +89,13 @@ importers:
         version: 20.19.25
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.0.0
-        version: 8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1)(typescript@5.7.3))(eslint@9.39.1)(typescript@5.7.3)
+        version: 8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.7.3))(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.7.3)
       '@typescript-eslint/parser':
         specifier: ^8.0.0
-        version: 8.48.0(eslint@9.39.1)(typescript@5.7.3)
+        version: 8.48.0(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.7.3)
       '@vitest/coverage-v8':
         specifier: ^3.1.3
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(terser@5.38.1))
+        version: 3.2.4(supports-color@7.2.0)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(supports-color@7.2.0)(terser@5.38.1))
       assert:
         specifier: ^2.1.0
         version: 2.1.0
@@ -104,7 +104,7 @@ importers:
         version: 6.0.3
       eslint:
         specifier: ^9.0.0
-        version: 9.39.1
+        version: 9.39.1(supports-color@7.2.0)
       events:
         specifier: ^3.3.0
         version: 3.3.0
@@ -125,13 +125,13 @@ importers:
         version: 5.7.3
       typescript-eslint:
         specifier: ^8.48.0
-        version: 8.48.0(eslint@9.39.1)(typescript@5.7.3)
+        version: 8.48.0(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.7.3)
       util:
         specifier: ^0.12.5
         version: 0.12.5
       vitest:
         specifier: ^3.1.3
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(terser@5.38.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(supports-color@7.2.0)(terser@5.38.1)
 
 packages:
 
@@ -916,11 +916,11 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  bn.js@4.12.2:
-    resolution: {integrity: sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==}
+  bn.js@4.12.5:
+    resolution: {integrity: sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==}
 
-  bn.js@5.2.2:
-    resolution: {integrity: sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==}
+  bn.js@5.2.5:
+    resolution: {integrity: sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==}
 
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -1958,17 +1958,17 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.1)':
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.1(supports-color@7.2.0))':
     dependencies:
-      eslint: 9.39.1
+      eslint: 9.39.1(supports-color@7.2.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint/config-array@0.21.1':
+  '@eslint/config-array@0.21.1(supports-color@7.2.0)':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -1981,10 +1981,10 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.3':
+  '@eslint/eslintrc@3.3.3(supports-color@7.2.0)':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -2294,15 +2294,15 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
-  '@typescript-eslint/eslint-plugin@8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1)(typescript@5.7.3))(eslint@9.39.1)(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.7.3))(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.48.0(eslint@9.39.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.48.0(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.48.0
-      '@typescript-eslint/type-utils': 8.48.0(eslint@9.39.1)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.48.0(eslint@9.39.1)(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.48.0(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.48.0(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.48.0
-      eslint: 9.39.1
+      eslint: 9.39.1(supports-color@7.2.0)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -2311,23 +2311,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.48.0(eslint@9.39.1)(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.48.0(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.48.0
       '@typescript-eslint/types': 8.48.0
-      '@typescript-eslint/typescript-estree': 8.48.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.48.0(supports-color@7.2.0)(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.48.0
-      debug: 4.4.3
-      eslint: 9.39.1
+      debug: 4.4.3(supports-color@7.2.0)
+      eslint: 9.39.1(supports-color@7.2.0)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.48.0(typescript@5.7.3)':
+  '@typescript-eslint/project-service@8.48.0(supports-color@7.2.0)(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.48.0(typescript@5.7.3)
       '@typescript-eslint/types': 8.48.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -2341,13 +2341,13 @@ snapshots:
     dependencies:
       typescript: 5.7.3
 
-  '@typescript-eslint/type-utils@8.48.0(eslint@9.39.1)(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@8.48.0(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/types': 8.48.0
-      '@typescript-eslint/typescript-estree': 8.48.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.48.0(eslint@9.39.1)(typescript@5.7.3)
-      debug: 4.4.3
-      eslint: 9.39.1
+      '@typescript-eslint/typescript-estree': 8.48.0(supports-color@7.2.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.48.0(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.7.3)
+      debug: 4.4.3(supports-color@7.2.0)
+      eslint: 9.39.1(supports-color@7.2.0)
       ts-api-utils: 2.1.0(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -2355,13 +2355,13 @@ snapshots:
 
   '@typescript-eslint/types@8.48.0': {}
 
-  '@typescript-eslint/typescript-estree@8.48.0(typescript@5.7.3)':
+  '@typescript-eslint/typescript-estree@8.48.0(supports-color@7.2.0)(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.48.0(typescript@5.7.3)
+      '@typescript-eslint/project-service': 8.48.0(supports-color@7.2.0)(typescript@5.7.3)
       '@typescript-eslint/tsconfig-utils': 8.48.0(typescript@5.7.3)
       '@typescript-eslint/types': 8.48.0
       '@typescript-eslint/visitor-keys': 8.48.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       minimatch: 9.0.5
       semver: 7.7.1
       tinyglobby: 0.2.15
@@ -2370,13 +2370,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.48.0(eslint@9.39.1)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.48.0(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.7.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1)
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(supports-color@7.2.0))
       '@typescript-eslint/scope-manager': 8.48.0
       '@typescript-eslint/types': 8.48.0
-      '@typescript-eslint/typescript-estree': 8.48.0(typescript@5.7.3)
-      eslint: 9.39.1
+      '@typescript-eslint/typescript-estree': 8.48.0(supports-color@7.2.0)(typescript@5.7.3)
+      eslint: 9.39.1(supports-color@7.2.0)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -2386,22 +2386,22 @@ snapshots:
       '@typescript-eslint/types': 8.48.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(terser@5.38.1))':
+  '@vitest/coverage-v8@3.2.4(supports-color@7.2.0)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(supports-color@7.2.0)(terser@5.38.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
       ast-v8-to-istanbul: 0.3.8
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
+      istanbul-lib-source-maps: 5.0.6(supports-color@7.2.0)
       istanbul-reports: 3.2.0
       magic-string: 0.30.17
       magicast: 0.3.5
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(terser@5.38.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(supports-color@7.2.0)(terser@5.38.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -2498,9 +2498,9 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  bn.js@4.12.2: {}
+  bn.js@4.12.5: {}
 
-  bn.js@5.2.2: {}
+  bn.js@5.2.5: {}
 
   brace-expansion@1.1.11:
     dependencies:
@@ -2609,9 +2609,11 @@ snapshots:
 
   crypto-js@4.2.0: {}
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
 
   deep-eql@5.0.2: {}
 
@@ -2641,7 +2643,7 @@ snapshots:
 
   elliptic@6.6.1:
     dependencies:
-      bn.js: 4.12.2
+      bn.js: 4.12.5
       brorand: 1.1.0
       hash.js: 1.1.7
       hmac-drbg: 1.0.1
@@ -2703,14 +2705,14 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.39.1:
+  eslint@9.39.1(supports-color@7.2.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1)
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(supports-color@7.2.0))
       '@eslint-community/regexpp': 4.12.1
-      '@eslint/config-array': 0.21.1
+      '@eslint/config-array': 0.21.1(supports-color@7.2.0)
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.3
+      '@eslint/eslintrc': 3.3.3(supports-color@7.2.0)
       '@eslint/js': 9.39.1
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.7
@@ -2720,7 +2722,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -2978,10 +2980,10 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6:
+  istanbul-lib-source-maps@5.0.6(supports-color@7.2.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -3386,13 +3388,13 @@ snapshots:
       es-errors: 1.3.0
       is-typed-array: 1.1.15
 
-  typescript-eslint@8.48.0(eslint@9.39.1)(typescript@5.7.3):
+  typescript-eslint@8.48.0(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1)(typescript@5.7.3))(eslint@9.39.1)(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.48.0(eslint@9.39.1)(typescript@5.7.3)
-      '@typescript-eslint/typescript-estree': 8.48.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.48.0(eslint@9.39.1)(typescript@5.7.3)
-      eslint: 9.39.1
+      '@typescript-eslint/eslint-plugin': 8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.7.3))(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.48.0(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.48.0(supports-color@7.2.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.48.0(eslint@9.39.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.7.3)
+      eslint: 9.39.1(supports-color@7.2.0)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -3415,10 +3417,10 @@ snapshots:
       is-typed-array: 1.1.15
       which-typed-array: 1.1.19
 
-  vite-node@3.2.4(@types/node@20.19.25)(terser@5.38.1):
+  vite-node@3.2.4(@types/node@20.19.25)(supports-color@7.2.0)(terser@5.38.1):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.2.4(@types/node@20.19.25)(terser@5.38.1)
@@ -3449,7 +3451,7 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.38.1
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(terser@5.38.1):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(supports-color@7.2.0)(terser@5.38.1):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -3460,7 +3462,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.3.3
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       expect-type: 1.2.2
       magic-string: 0.30.17
       pathe: 2.0.3
@@ -3472,7 +3474,7 @@ snapshots:
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 7.2.4(@types/node@20.19.25)(terser@5.38.1)
-      vite-node: 3.2.4(@types/node@20.19.25)(terser@5.38.1)
+      vite-node: 3.2.4(@types/node@20.19.25)(supports-color@7.2.0)(terser@5.38.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12


### PR DESCRIPTION
## Summary

Remediates Dependabot alerts #259 / #260 on **`bn.js`** — both are the same advisory, [CVE-2026-2739 / GHSA-378v-28hj-76wf](https://github.com/advisories/GHSA-378v-28hj-76wf) (`maskn(0)` corrupts a `BN`'s internal state, so a later `toString()` / `divmod()` hangs the process).

`bn.js` is a **runtime dependency** and two copies are inlined into the published `dist` bundles: the direct dependency used by `src/auth/ecc/src/`, and a transitive copy pulled in by `elliptic`.

| Alert | Copy | Before | After |
| --- | --- | --- | --- |
| #260 | direct | 5.2.2 | 5.2.5 (floor raised to `^5.2.3`) |
| #259 | transitive (via `elliptic`) | 4.12.2 | 4.12.5 |

## Changes

- Raise the direct dependency floor from `^5.2.2` to `^5.2.3`, the first patched 5.x. The floor is deliberately left at the patched version rather than the newest one so downstream projects can still dedupe; the lockfile resolves to 5.2.5.
- Refresh the lockfile so `elliptic`'s declared `^4.11.9` range resolves to **4.12.5**.
- Bump the package version to **1.1.1** and add a `CHANGELOG.md` entry, so downstream consumers (wallet, condenser) can pick the fix up from a published release.

### Why no pnpm override

An earlier revision of this PR forced the transitive copy with a pnpm override (`'bn.js@4.12.2': '4.12.3'`). That turned out to be both unnecessary and harmful:

- Plain resolution of `^4.11.9` already yields **4.12.5**, which is *newer* than the pinned 4.12.3 — the override was effectively a downgrade that also blocked future 4.12.x patches.
- pnpm matches an override key by testing whether the key's range is a subset of the range declared by the dependent. `4.12.2` only matches while `elliptic` declares a range containing it; if `elliptic` ever narrows its range (or is replaced), the override becomes a **silent no-op with no warning**, and the vulnerable version can return unnoticed.

So the override was dropped and the lockfile simply refreshed. `pnpm-workspace.yaml` is unchanged relative to `master`.

## Verification

- `pnpm install --frozen-lockfile` — lockfile consistent with `package.json`
- `pnpm typecheck` — pass
- `pnpm lint` — no errors
- `pnpm test` — 279 passed, 23 skipped
- `pnpm build` — all four bundles produced; both `bn.js` copies inlined into `dist/browser.esm.js` and `dist/index.umd.js` carry the `imaskn` fix, and `new BN(255).maskn(0)` returns immediately instead of hanging.

> Note: `.github/workflows/build.yml` currently restricts its `pull_request` trigger to `paths: ['.github/workflows/build.yml']`, so CI does not run on dependency PRs like this one. Worth fixing separately.