### PR TITLE
chore(publish): declare publishConfig.access = public

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
   ],
   "author": "hightouch",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=20.19.0"
   },


### PR DESCRIPTION
## Summary

`@steemit/steem-js` is a **scoped** package, so npm defaults to a `restricted` (private) publish. Every release so far has depended on the publisher remembering to pass `--access public` on the command line; forgetting it once would silently push the package out as private and break every downstream install.

Declaring it in `publishConfig` makes the default correct, so `pnpm publish` is enough and the manual flag drops off the release checklist. This was a standing TODO before the 1.1.1 release.

```json
"publishConfig": {
  "access": "public"
},
```

## Verification

`npm publish --dry-run --ignore-scripts` packs the expected 58-file tarball from `dist`, and `npm pkg get publishConfig` reports `{ "access": "public" }`.

## Note

Please merge this before tagging `v1.1.1`, so the tag points at the same tree that gets published.